### PR TITLE
Add response rendering, history logging, and activation/deactivation flow

### DIFF
--- a/bin/lacy
+++ b/bin/lacy
@@ -631,10 +631,17 @@ cmd_help() {
 ${BOLD}Lacy Shell${NC} ${DIM}v${VERSION}${NC} — Talk directly to your shell
 
 ${BOLD}Usage:${NC}
-  lacy                Enter Lacy Shell (or re-enter after quit)
-  lacy [command]      Run a command
+  lacy                Activate Lacy Shell (or show status if already active)
+  lacy on             Activate Lacy Shell explicitly
+  lacy off            Deactivate Lacy Shell, return to normal shell
+  lacy [command]      Run a CLI command
 
-${BOLD}Commands:${NC}
+${BOLD}Activation commands${NC} (type in your shell):
+  lacy on             Activate — hook into your shell
+  lacy off            Deactivate — restore normal shell behaviour
+  lacy                Toggle: activate if off, show status if on
+
+${BOLD}CLI commands:${NC}
   setup          Interactive settings (tool, mode, config)
   install        Install Lacy Shell (interactive)
   uninstall      Remove Lacy Shell completely
@@ -654,6 +661,7 @@ ${BOLD}In-shell commands${NC} (available when Lacy is active):
   Ctrl+Space     Toggle between modes
 
 ${BOLD}Environment:${NC}
+  LACY_AUTO_START=false     Load functions but don't activate on shell start
   LACY_NO_NODE=1            Force bash-only mode (skip Node UI)
 
 ${DIM}https://github.com/lacymorrow/lacy${NC}

--- a/lacy.plugin.bash
+++ b/lacy.plugin.bash
@@ -2,12 +2,11 @@
 
 # Lacy Shell - Smart shell plugin with MCP support (Bash adapter)
 
-# Prevent multiple sourcing
+# Prevent multiple sourcing of module definitions
 if [[ "${LACY_SHELL_LOADED:-}" == "true" ]]; then
     return 0
 fi
 LACY_SHELL_LOADED=true
-export LACY_SHELL_ACTIVE=1
 
 # Plugin directory
 LACY_SHELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,17 +15,15 @@ LACY_SHELL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LACY_SHELL_TYPE="bash"
 _LACY_ARR_OFFSET=0
 
-# Load shared core + Bash adapter modules
+# Load shared core + Bash adapter modules (defines functions, does NOT activate)
 source "$LACY_SHELL_DIR/lib/bash/init.bash" || {
     LACY_SHELL_LOADED=false
     return 1
 }
 
-# Initialize
+# Initialize internals — called from lacy_shell_activate
 lacy_shell_init() {
-    # Performance optimization: Initialize caches early
     lacy_shell_init_detection_cache
-
     lacy_shell_load_config
     lacy_shell_setup_keybindings
     lacy_shell_init_mcp
@@ -37,7 +34,7 @@ lacy_shell_init() {
     lacy_shell_setup_eof_handler
 }
 
-# Cleanup
+# Cleanup — called on deactivation and shell EXIT trap
 lacy_shell_cleanup() {
     lacy_stop_spinner 2>/dev/null
     lacy_preheat_cleanup
@@ -46,27 +43,65 @@ lacy_shell_cleanup() {
     trap - INT
     unset IGNOREEOF
     # Restore original PROMPT_COMMAND
-    if [[ -n "$_LACY_ORIGINAL_PROMPT_COMMAND" ]]; then
+    if [[ -n "${_LACY_ORIGINAL_PROMPT_COMMAND+x}" ]]; then
         PROMPT_COMMAND="$_LACY_ORIGINAL_PROMPT_COMMAND"
-    else
-        PROMPT_COMMAND=""
+        unset _LACY_ORIGINAL_PROMPT_COMMAND
     fi
     LACY_SHELL_QUITTING=false
     LACY_SHELL_ENABLED=false
-    LACY_SHELL_LOADED=false
     unset LACY_SHELL_ACTIVE
 }
 
-# Set up PROMPT_COMMAND for post-execution hooks
-_LACY_ORIGINAL_PROMPT_COMMAND="${PROMPT_COMMAND:-}"
-if [[ -n "$PROMPT_COMMAND" ]]; then
-    PROMPT_COMMAND="lacy_shell_precmd_bash; ${PROMPT_COMMAND}"
-else
-    PROMPT_COMMAND="lacy_shell_precmd_bash"
+# Activate: hook into Bash and start Lacy Shell.
+# Safe to call multiple times — guards against double-activation.
+lacy_shell_activate() {
+    if [[ "${LACY_SHELL_ACTIVE:-}" == "1" ]]; then
+        printf '\e[38;5;200m  Lacy is already active  (type '"'"'lacy off'"'"' to deactivate)\e[0m\n'
+        return 0
+    fi
+
+    LACY_SHELL_ENABLED=true
+    export LACY_SHELL_ACTIVE=1
+
+    # Capture current PROMPT_COMMAND so cleanup can restore it
+    _LACY_ORIGINAL_PROMPT_COMMAND="${PROMPT_COMMAND:-}"
+    if [[ -n "$PROMPT_COMMAND" ]]; then
+        PROMPT_COMMAND="lacy_shell_precmd_bash; ${PROMPT_COMMAND}"
+    else
+        PROMPT_COMMAND="lacy_shell_precmd_bash"
+    fi
+
+    lacy_shell_init
+    trap lacy_shell_cleanup EXIT
+}
+
+# lacy() — persistent shell function, survives deactivation.
+lacy() {
+    case "${1:-}" in
+        on|start|activate)
+            lacy_shell_activate
+            ;;
+        off|stop|deactivate)
+            lacy_shell_quit
+            ;;
+        "")
+            if [[ "${LACY_SHELL_ACTIVE:-}" == "1" ]]; then
+                command lacy status
+            else
+                lacy_shell_activate
+            fi
+            ;;
+        *)
+            command lacy "$@"
+            ;;
+    esac
+}
+
+# ============================================================================
+# Auto-start
+# Default: activate immediately (preserves existing behaviour).
+# To suppress: export LACY_AUTO_START=false  (in .bashrc, before sourcing lacy)
+# ============================================================================
+if [[ "${LACY_AUTO_START:-true}" != "false" ]]; then
+    lacy_shell_activate
 fi
-
-# Initialize
-lacy_shell_init
-
-# Cleanup on exit
-trap lacy_shell_cleanup EXIT

--- a/lacy.plugin.zsh
+++ b/lacy.plugin.zsh
@@ -2,12 +2,11 @@
 
 # Lacy Shell - Smart shell plugin with MCP support
 
-# Prevent multiple sourcing
+# Prevent multiple sourcing of module definitions
 if [[ "${LACY_SHELL_LOADED:-}" == "true" ]]; then
     return 0
 fi
 LACY_SHELL_LOADED=true
-export LACY_SHELL_ACTIVE=1
 
 # Plugin directory
 LACY_SHELL_DIR="${0:A:h}"
@@ -16,14 +15,12 @@ LACY_SHELL_DIR="${0:A:h}"
 LACY_SHELL_TYPE="zsh"
 _LACY_ARR_OFFSET=1
 
-# Load shared core + ZSH adapter modules
+# Load shared core + ZSH adapter modules (defines functions, does NOT activate)
 source "$LACY_SHELL_DIR/lib/zsh/init.zsh"
 
-# Initialize
+# Initialize internals — called from lacy_shell_activate
 lacy_shell_init() {
-    # Performance optimization: Initialize caches early
     lacy_shell_init_detection_cache
-
     lacy_shell_load_config
     lacy_shell_setup_keybindings
     lacy_shell_init_mcp
@@ -34,7 +31,7 @@ lacy_shell_init() {
     lacy_shell_setup_eof_handler
 }
 
-# Cleanup
+# Cleanup — called on deactivation and shell EXIT trap
 lacy_shell_cleanup() {
     lacy_stop_spinner 2>/dev/null
     lacy_shell_remove_top_bar
@@ -47,17 +44,59 @@ lacy_shell_cleanup() {
     unset IGNOREEOF
     LACY_SHELL_QUITTING=false
     LACY_SHELL_ENABLED=false
-    LACY_SHELL_LOADED=false
     unset LACY_SHELL_ACTIVE
 }
 
-# Set up hooks
-zle -N accept-line lacy_shell_smart_accept_line
-preexec_functions+=(lacy_shell_preexec)
-precmd_functions+=(lacy_shell_precmd)
+# Activate: hook into ZSH and start Lacy Shell.
+# Safe to call multiple times — guards against double-activation.
+lacy_shell_activate() {
+    if [[ "${LACY_SHELL_ACTIVE:-}" == "1" ]]; then
+        lacy_print_color "${LACY_COLOR_AGENT}" "  Lacy is already active  (type 'lacy off' to deactivate)"
+        return 0
+    fi
 
-# Initialize
-lacy_shell_init
+    LACY_SHELL_ENABLED=true
+    export LACY_SHELL_ACTIVE=1
 
-# Cleanup on exit
-trap lacy_shell_cleanup EXIT
+    # Hook into ZSH
+    zle -N accept-line lacy_shell_smart_accept_line
+    preexec_functions+=(lacy_shell_preexec)
+    precmd_functions+=(lacy_shell_precmd)
+
+    lacy_shell_init
+    trap lacy_shell_cleanup EXIT
+}
+
+# lacy() — persistent shell function, survives deactivation.
+# Routes `lacy on/off` to activation/deactivation; delegates everything
+# else to the `lacy` CLI binary.
+lacy() {
+    case "${1:-}" in
+        on|start|activate)
+            lacy_shell_activate
+            ;;
+        off|stop|deactivate)
+            lacy_shell_quit
+            ;;
+        "")
+            # No args while active → show status; while inactive → activate
+            if [[ "${LACY_SHELL_ACTIVE:-}" == "1" ]]; then
+                command lacy status
+            else
+                lacy_shell_activate
+            fi
+            ;;
+        *)
+            command lacy "$@"
+            ;;
+    esac
+}
+
+# ============================================================================
+# Auto-start
+# Default: activate immediately (preserves existing behaviour).
+# To suppress: export LACY_AUTO_START=false  (in .zshrc, before sourcing lacy)
+# ============================================================================
+if [[ "${LACY_AUTO_START:-true}" != "false" ]]; then
+    lacy_shell_activate
+fi

--- a/lacy.plugin.zsh
+++ b/lacy.plugin.zsh
@@ -53,6 +53,7 @@ lacy_shell_cleanup() {
 
 # Set up hooks
 zle -N accept-line lacy_shell_smart_accept_line
+preexec_functions+=(lacy_shell_preexec)
 precmd_functions+=(lacy_shell_precmd)
 
 # Initialize

--- a/lib/bash/execute.bash
+++ b/lib/bash/execute.bash
@@ -108,10 +108,29 @@ lacy_shell_execute_agent() {
     fi
 }
 
+# Last HISTCMD value logged — prevents logging the same entry twice
+_LACY_LAST_HISTCMD=""
+
 # Precmd equivalent for Bash — called via PROMPT_COMMAND
 lacy_shell_precmd_bash() {
     # Capture exit code immediately
     _lacy_last_exit=$?
+
+    # Log last shell command via Bash history (no preexec equivalent in Bash)
+    if [[ -n "$HISTCMD" && "$HISTCMD" != "$_LACY_LAST_HISTCMD" ]]; then
+        local _raw _num _last_cmd
+        _raw=$(HISTTIMEFORMAT='' builtin history 1 2>/dev/null)
+        # Strip leading whitespace, then strip history number, then strip whitespace
+        _raw="${_raw#"${_raw%%[![:space:]]*}"}"
+        _num="${_raw%%[[:space:]]*}"
+        _last_cmd="${_raw#"${_num}"}"
+        _last_cmd="${_last_cmd#"${_last_cmd%%[![:space:]]*}"}"
+        # Only log if it looks like a real command (not an agent query already handled)
+        if [[ -n "$_last_cmd" && "$_last_cmd" != "$LACY_SHELL_PENDING_QUERY" ]]; then
+            lacy_history_log "$_last_cmd" "$_lacy_last_exit"
+        fi
+        _LACY_LAST_HISTCMD="$HISTCMD"
+    fi
 
     # Ensure terminal state is clean
     printf '\e[?25h'   # Cursor visible

--- a/lib/bash/execute.bash
+++ b/lib/bash/execute.bash
@@ -335,28 +335,15 @@ lacy_shell_quit() {
     # Stop preheated servers
     lacy_preheat_cleanup
 
-    # Unset functions used as commands
-    unset -f ask mode tool spinner quit stop 2>/dev/null
-
-    # Define a `lacy` function so user can re-enter by typing `lacy`
-    local _ldir="$LACY_SHELL_DIR"
-    eval "lacy() {
-        if [[ \$# -eq 0 ]]; then
-            unset -f lacy 2>/dev/null
-            LACY_SHELL_LOADED=false
-            source \"${_ldir}/lacy.plugin.bash\"
-        else
-            command lacy \"\$@\"
-        fi
-    }"
-
     # Restore prompt
     lacy_shell_restore_prompt
 
     echo ""
+    echo "Lacy Shell deactivated."
+    printf '\e[38;5;238m  Type '"'"'lacy on'"'"' (or just '"'"'lacy'"'"') to re-enter.\e[0m\n'
+    echo ""
 
     LACY_SHELL_QUITTING=false
-    LACY_SHELL_LOADED=false
 }
 
 # Conversation management

--- a/lib/bash/init.bash
+++ b/lib/bash/init.bash
@@ -27,6 +27,7 @@ source "$LACY_SHELL_DIR/lib/core/modes.sh"
 source "$LACY_SHELL_DIR/lib/core/animations.sh"
 source "$LACY_SHELL_DIR/lib/core/spinner.sh"
 source "$LACY_SHELL_DIR/lib/core/mcp.sh"
+source "$LACY_SHELL_DIR/lib/core/render.sh"
 source "$LACY_SHELL_DIR/lib/core/preheat.sh"
 source "$LACY_SHELL_DIR/lib/core/detection.sh"
 

--- a/lib/bash/init.bash
+++ b/lib/bash/init.bash
@@ -28,6 +28,7 @@ source "$LACY_SHELL_DIR/lib/core/animations.sh"
 source "$LACY_SHELL_DIR/lib/core/spinner.sh"
 source "$LACY_SHELL_DIR/lib/core/mcp.sh"
 source "$LACY_SHELL_DIR/lib/core/render.sh"
+source "$LACY_SHELL_DIR/lib/core/history.sh"
 source "$LACY_SHELL_DIR/lib/core/preheat.sh"
 source "$LACY_SHELL_DIR/lib/core/detection.sh"
 

--- a/lib/core/history.sh
+++ b/lib/core/history.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Shell execution history capture for Lacy Shell
+# Logs commands + exit codes to conversation.log.
+# Shared across Bash 4+ and ZSH.
+
+# Last command captured by preexec (ZSH) or precmd (Bash)
+LACY_LAST_CMD=""
+
+# Append a completed command + exit code to conversation.log.
+# Usage: lacy_history_log "command text" exit_code
+lacy_history_log() {
+    local cmd="$1"
+    local exit_code="${2:-0}"
+
+    [[ -z "$cmd" ]] && return
+    [[ -z "$LACY_SHELL_CONVERSATION_FILE" ]] && return
+
+    # Skip internal lacy function calls
+    [[ "$cmd" == lacy_* || "$cmd" == _lacy_* ]] && return
+
+    local timestamp
+    timestamp=$(date +%H:%M:%S 2>/dev/null) || timestamp=""
+
+    {
+        printf 'CMD: %s\n' "$cmd"
+        printf 'EXIT: %s\n' "$exit_code"
+        [[ -n "$timestamp" ]] && printf 'TS: %s\n' "$timestamp"
+        printf -- '---\n'
+    } >> "$LACY_SHELL_CONVERSATION_FILE"
+}
+
+# Return a query enriched with recent command history as context.
+# Reads the last few entries from conversation.log.
+# Usage: enriched=$(lacy_build_context_query "user query")
+lacy_build_context_query() {
+    local query="$1"
+    local max_entries=5
+
+    if [[ ! -f "$LACY_SHELL_CONVERSATION_FILE" ]]; then
+        printf '%s' "$query"
+        return
+    fi
+
+    local raw
+    raw=$(tail -n $(( max_entries * 4 )) "$LACY_SHELL_CONVERSATION_FILE" 2>/dev/null)
+
+    if [[ -z "$raw" ]]; then
+        printf '%s' "$query"
+        return
+    fi
+
+    # Parse log entries into readable context
+    local context="Recent shell commands:"$'\n'
+    local line cmd="" exit_code=""
+    while IFS= read -r line; do
+        case "$line" in
+            "CMD: "*) cmd="${line#CMD: }" ;;
+            "EXIT: "*) exit_code="${line#EXIT: }" ;;
+            ---)
+                if [[ -n "$cmd" ]]; then
+                    context+="  \$ ${cmd}"
+                    [[ -n "$exit_code" && "$exit_code" != "0" ]] && context+="  (exit ${exit_code})"
+                    context+=$'\n'
+                fi
+                cmd="" exit_code=""
+                ;;
+        esac
+    done <<< "$raw"
+
+    printf '%s\n\n%s' "$context" "$query"
+}

--- a/lib/core/history.sh
+++ b/lib/core/history.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Shell execution history capture for Lacy Shell
+# Shell execution history capture + query enrichment for Lacy Shell
 # Logs commands + exit codes to conversation.log.
 # Shared across Bash 4+ and ZSH.
 
@@ -28,6 +28,58 @@ lacy_history_log() {
         [[ -n "$timestamp" ]] && printf 'TS: %s\n' "$timestamp"
         printf -- '---\n'
     } >> "$LACY_SHELL_CONVERSATION_FILE"
+}
+
+# ============================================================================
+# Feature 2: @file reference expansion
+#
+# Scans a query string for @path tokens. For each token that resolves to a
+# readable file, the file's contents are appended to the query so the agent
+# can read them directly.
+#
+# Rules:
+#   - Token must start with @ and contain at least one non-@ character
+#   - Trailing punctuation (,.;:!?) is stripped before resolving
+#   - Files larger than 8 KB are truncated
+#   - Each file is included at most once (deduplication)
+#
+# Usage: expanded=$(lacy_expand_file_refs "fix the bug in @src/main.go")
+# ============================================================================
+LACY_EXPANDED_FILES=()   # populated by lacy_expand_file_refs, read by mcp.sh
+
+lacy_expand_file_refs() {
+    local query="$1"
+    local result="$query"
+    local seen=":"   # colon-delimited list of already-expanded paths
+    LACY_EXPANDED_FILES=()
+
+    local tmp="$query"
+    while [[ "$tmp" == *"@"* ]]; do
+        tmp="${tmp#*@}"                         # advance past the next @
+        local token="${tmp%%[[:space:]]*}"       # grab word up to whitespace
+        tmp="${tmp#"$token"}"                   # advance past the token
+
+        [[ -z "$token" ]] && continue
+
+        # Strip trailing punctuation characters
+        local path="$token"
+        while [[ -n "$path" && "${path: -1}" == [,.:;!?] ]]; do
+            path="${path%?}"
+        done
+
+        [[ -z "$path" ]] && continue
+
+        # Expand readable files not yet seen
+        if [[ -f "$path" && -r "$path" && "$seen" != *":${path}:"* ]]; then
+            seen+=":${path}:"
+            LACY_EXPANDED_FILES+=("$path")
+            local contents
+            contents=$(head -c 8192 "$path" 2>/dev/null)
+            result+=$'\n\n'"--- @${path} ---"$'\n'"${contents}"$'\n'"---"
+        fi
+    done
+
+    printf '%s' "$result"
 }
 
 # Return a query enriched with recent command history as context.

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -241,7 +241,9 @@ except: pass" 2>/dev/null)
 
 # Send query to AI agent (configurable tool or fallback)
 lacy_shell_query_agent() {
-    local query="$1"
+    local query
+    # Enrich query with recent shell history context if available
+    query=$(lacy_build_context_query "$1")
     local tool="${LACY_ACTIVE_TOOL}"
 
     # Auto-detect if not set

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -385,7 +385,7 @@ EOF
             lacy_preheat_server_restore_session
             if [[ $exit_code -eq 0 && -n "$server_result" ]]; then
                 while [[ "$server_result" == $'\n'* ]]; do server_result="${server_result#$'\n'}"; done
-                printf '%s\n' "$server_result"
+                printf '%s\n' "$server_result" | lacy_render_response
                 _lacy_print_resume_hint "$tool"
                 echo ""
                 return 0
@@ -417,9 +417,9 @@ EOF
             result_text=$(lacy_preheat_claude_extract_result "$json_output")
             while [[ "$result_text" == $'\n'* ]]; do result_text="${result_text#$'\n'}"; done
             if [[ -n "$result_text" ]]; then
-                printf '%s\n' "$result_text"
+                printf '%s\n' "$result_text" | lacy_render_response
             else
-                printf '%s\n' "$json_output"
+                printf '%s\n' "$json_output" | lacy_render_response
             fi
             lacy_preheat_claude_capture_session "$json_output"
             _lacy_print_resume_hint "$tool"
@@ -446,9 +446,9 @@ EOF
                 result_text=$(lacy_preheat_claude_extract_result "$json_output")
                 while [[ "$result_text" == $'\n'* ]]; do result_text="${result_text#$'\n'}"; done
                 if [[ -n "$result_text" ]]; then
-                    printf '%s\n' "$result_text"
+                    printf '%s\n' "$result_text" | lacy_render_response
                 else
-                    printf '%s\n' "$json_output"
+                    printf '%s\n' "$json_output" | lacy_render_response
                 fi
                 lacy_preheat_claude_capture_session "$json_output"
                 _lacy_print_resume_hint "$tool"
@@ -490,9 +490,9 @@ EOF
             if (( _line_count > 1 )); then
                 # Multi-line output — not a JSON error blob, flush everything
                 if [[ $_line_count -eq 2 ]]; then
-                    printf '%s\n' "$_full_output"
+                    _lacy_render_line "$_full_output"
                 fi
-                printf '%s\n' "$line"
+                _lacy_render_line "$line"
             fi
         done
         if ! $_spinner_killed && [[ -n "$LACY_SPINNER_PID" ]]; then
@@ -502,7 +502,7 @@ EOF
         fi
         # Single-line output — check if it's a JSON error
         if (( _line_count <= 1 )); then
-            lacy_format_tool_error "$_full_output" "$tool" || printf '%s\n' "$_full_output"
+            lacy_format_tool_error "$_full_output" "$tool" || _lacy_render_line "$_full_output"
         fi
     }
     local exit_code

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -242,8 +242,15 @@ except: pass" 2>/dev/null)
 # Send query to AI agent (configurable tool or fallback)
 lacy_shell_query_agent() {
     local query
-    # Enrich query with recent shell history context if available
-    query=$(lacy_build_context_query "$1")
+    # Feature 2: expand @file references in the query
+    query=$(lacy_expand_file_refs "$1")
+    # Show which files are being included (before spinner starts)
+    local _f
+    for _f in "${LACY_EXPANDED_FILES[@]}"; do
+        lacy_print_color 238 "  @${_f}"
+    done
+    # Feature 5: enrich with recent shell history context
+    query=$(lacy_build_context_query "$query")
     local tool="${LACY_ACTIVE_TOOL}"
 
     # Auto-detect if not set

--- a/lib/core/render.sh
+++ b/lib/core/render.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Output rendering for Lacy Shell
+# Post-processes agent response text before display.
+# Shared across Bash 4+ and ZSH.
+
+# ============================================================================
+# Feature 1: Todo list rendering
+# Converts markdown checkboxes to terminal symbols with color.
+#   - [ ] item  →  ☐ item  (gray/238)
+#   - [x] item  →  ☑ item  (green/34)
+# ============================================================================
+
+# Render a single line — called inline or from lacy_render_response.
+# Usage: _lacy_render_line "line text"
+_lacy_render_line() {
+    local line="$1"
+
+    # Strip leading whitespace to check prefix (preserves indent for output)
+    local stripped="$line"
+    while [[ "${stripped:0:1}" == " " || "${stripped:0:1}" == $'\t' ]]; do
+        stripped="${stripped:1}"
+    done
+    local indent="${line:0:$(( ${#line} - ${#stripped} ))}"
+
+    if [[ "$stripped" == "- [ ] "* ]]; then
+        lacy_print_color 238 "${indent}☐ ${stripped#"- [ ] "}"
+    elif [[ "$stripped" == "- [x] "* ]]; then
+        lacy_print_color 34 "${indent}☑ ${stripped#"- [x] "}"
+    elif [[ "$stripped" == "- [X] "* ]]; then
+        lacy_print_color 34 "${indent}☑ ${stripped#"- [X] "}"
+    else
+        printf '%s\n' "$line"
+    fi
+}
+
+# Render agent response from stdin, line by line.
+# Usage: printf '%s\n' "$result" | lacy_render_response
+lacy_render_response() {
+    local line
+    while IFS= read -r line; do
+        _lacy_render_line "$line"
+    done
+    # Handle output that doesn't end with a newline
+    [[ -n "$line" ]] && _lacy_render_line "$line"
+}

--- a/lib/core/render.sh
+++ b/lib/core/render.sh
@@ -4,19 +4,51 @@
 # Post-processes agent response text before display.
 # Shared across Bash 4+ and ZSH.
 
-# ============================================================================
-# Feature 1: Todo list rendering
-# Converts markdown checkboxes to terminal symbols with color.
-#   - [ ] item  →  ☐ item  (gray/238)
-#   - [x] item  →  ☑ item  (green/34)
-# ============================================================================
+# State: are we currently inside a fenced code block?
+# Persists across _lacy_render_line calls in the same process.
+_LACY_IN_CODE_BLOCK=0
+_LACY_CODE_BLOCK_LANG=""
 
-# Render a single line — called inline or from lacy_render_response.
-# Usage: _lacy_render_line "line text"
+# ============================================================================
+# _lacy_render_line "line"
+#
+# Handles (in order of priority):
+#   Feature 4a: fenced code blocks (``` ... ```) — dim fence, preserve content
+#   Feature 4b: diff lines inside code blocks — green/red/cyan coloring
+#   Feature 1:  markdown todo items outside code blocks — ☐/☑ symbols
+# ============================================================================
 _lacy_render_line() {
     local line="$1"
 
-    # Strip leading whitespace to check prefix (preserves indent for output)
+    # --- Feature 4a: fenced code block toggle ---
+    if [[ "$line" == '```'* ]]; then
+        if (( _LACY_IN_CODE_BLOCK == 0 )); then
+            _LACY_IN_CODE_BLOCK=1
+            _LACY_CODE_BLOCK_LANG="${line#'```'}"
+            lacy_print_color 238 "$line"
+        else
+            _LACY_IN_CODE_BLOCK=0
+            _LACY_CODE_BLOCK_LANG=""
+            lacy_print_color 238 "$line"
+        fi
+        return
+    fi
+
+    # --- Feature 4b: inside a code block ---
+    if (( _LACY_IN_CODE_BLOCK == 1 )); then
+        # Diff coloring (unified diff format)
+        case "$line" in
+            "@@"*"@@"*) lacy_print_color 75  "$line" ;; # cyan  — hunk header
+            "--- "*)     lacy_print_color 238 "$line" ;; # gray  — old file header
+            "+++ "*)     lacy_print_color 238 "$line" ;; # gray  — new file header
+            "+"*)        lacy_print_color 34  "$line" ;; # green — added line
+            "-"*)        lacy_print_color 196 "$line" ;; # red   — removed line
+            *)           printf '%s\n' "$line" ;;
+        esac
+        return
+    fi
+
+    # --- Feature 1: markdown todo items (outside code blocks) ---
     local stripped="$line"
     while [[ "${stripped:0:1}" == " " || "${stripped:0:1}" == $'\t' ]]; do
         stripped="${stripped:1}"
@@ -34,9 +66,17 @@ _lacy_render_line() {
     fi
 }
 
-# Render agent response from stdin, line by line.
+# ============================================================================
+# lacy_render_response
+#
+# Read agent response from stdin, render line by line.
+# Resets code-block state at the start of each response so buffered
+# paths (server/claude) always start clean.
 # Usage: printf '%s\n' "$result" | lacy_render_response
+# ============================================================================
 lacy_render_response() {
+    _LACY_IN_CODE_BLOCK=0
+    _LACY_CODE_BLOCK_LANG=""
     local line
     while IFS= read -r line; do
         _lacy_render_line "$line"

--- a/lib/core/render.sh
+++ b/lib/core/render.sh
@@ -4,39 +4,72 @@
 # Post-processes agent response text before display.
 # Shared across Bash 4+ and ZSH.
 
-# State: are we currently inside a fenced code block?
-# Persists across _lacy_render_line calls in the same process.
+# ============================================================================
+# State (persists across _lacy_render_line calls in the same process)
+# ============================================================================
 _LACY_IN_CODE_BLOCK=0
 _LACY_CODE_BLOCK_LANG=""
 
+# Temp buffers for thinking extraction (set by _lacy_extract_thinking)
+_LACY_THINKING_CONTENT=""
+_LACY_RESPONSE_BODY=""
+
 # ============================================================================
-# _lacy_render_line "line"
+# Feature 3: <thinking> block extraction
 #
-# Handles (in order of priority):
-#   Feature 4a: fenced code blocks (``` ... ```) — dim fence, preserve content
-#   Feature 4b: diff lines inside code blocks — green/red/cyan coloring
-#   Feature 1:  markdown todo items outside code blocks — ☐/☑ symbols
+# Strips <thinking>...</thinking> sections from raw response text.
+# Results are stored in _LACY_THINKING_CONTENT and _LACY_RESPONSE_BODY.
+# Usage: _lacy_extract_thinking "$raw_text"
+# ============================================================================
+_lacy_extract_thinking() {
+    local raw="$1"
+
+    if [[ "$raw" != *"<thinking>"* ]]; then
+        _LACY_THINKING_CONTENT=""
+        _LACY_RESPONSE_BODY="$raw"
+        return
+    fi
+
+    local thinking_parts="" remainder="$raw"
+    while [[ "$remainder" == *"<thinking>"* ]]; do
+        local before="${remainder%%<thinking>*}"
+        local after="${remainder#*<thinking>}"
+        local thought="${after%%</thinking>*}"
+        local rest="${after#*</thinking>}"
+        thinking_parts+="${thought}"$'\n'
+        remainder="${before}${rest}"
+    done
+
+    _LACY_THINKING_CONTENT="${thinking_parts%$'\n'}"  # strip trailing newline
+    _LACY_RESPONSE_BODY="$remainder"
+}
+
+# ============================================================================
+# Feature 4 + 1: line-level rendering
+#
+# Priority:
+#   4a: fenced code blocks (``` ... ```) — dim fence, track state
+#   4b: diff lines inside code blocks — green/red/cyan
+#   1:  markdown todo items outside code blocks — ☐/☑
 # ============================================================================
 _lacy_render_line() {
     local line="$1"
 
-    # --- Feature 4a: fenced code block toggle ---
+    # 4a: code block fence toggle
     if [[ "$line" == '```'* ]]; then
         if (( _LACY_IN_CODE_BLOCK == 0 )); then
             _LACY_IN_CODE_BLOCK=1
             _LACY_CODE_BLOCK_LANG="${line#'```'}"
-            lacy_print_color 238 "$line"
         else
             _LACY_IN_CODE_BLOCK=0
             _LACY_CODE_BLOCK_LANG=""
-            lacy_print_color 238 "$line"
         fi
+        lacy_print_color 238 "$line"
         return
     fi
 
-    # --- Feature 4b: inside a code block ---
+    # 4b: inside a code block — apply diff coloring
     if (( _LACY_IN_CODE_BLOCK == 1 )); then
-        # Diff coloring (unified diff format)
         case "$line" in
             "@@"*"@@"*) lacy_print_color 75  "$line" ;; # cyan  — hunk header
             "--- "*)     lacy_print_color 238 "$line" ;; # gray  — old file header
@@ -48,7 +81,7 @@ _lacy_render_line() {
         return
     fi
 
-    # --- Feature 1: markdown todo items (outside code blocks) ---
+    # 1: markdown todo items (outside code blocks only)
     local stripped="$line"
     while [[ "${stripped:0:1}" == " " || "${stripped:0:1}" == $'\t' ]]; do
         stripped="${stripped:1}"
@@ -69,18 +102,35 @@ _lacy_render_line() {
 # ============================================================================
 # lacy_render_response
 #
-# Read agent response from stdin, render line by line.
-# Resets code-block state at the start of each response so buffered
-# paths (server/claude) always start clean.
+# Read agent response from stdin and render it:
+#   1. Extract <thinking> blocks → show in dim gray with a border
+#   2. Render body line by line (todos, code blocks, diffs)
+#
 # Usage: printf '%s\n' "$result" | lacy_render_response
 # ============================================================================
 lacy_render_response() {
     _LACY_IN_CODE_BLOCK=0
     _LACY_CODE_BLOCK_LANG=""
+
+    local raw
+    raw=$(cat)
+
+    # Feature 3: extract and display thinking blocks
+    _lacy_extract_thinking "$raw"
+
+    if [[ -n "$_LACY_THINKING_CONTENT" ]]; then
+        lacy_print_color 238 "╭─ Thinking"
+        local t_line
+        while IFS= read -r t_line; do
+            lacy_print_color 238 "│ ${t_line}"
+        done <<< "$_LACY_THINKING_CONTENT"
+        lacy_print_color 238 "╰─"
+        echo ""
+    fi
+
+    # Render body line by line
     local line
     while IFS= read -r line; do
         _lacy_render_line "$line"
-    done
-    # Handle output that doesn't end with a newline
-    [[ -n "$line" ]] && _lacy_render_line "$line"
+    done <<< "$_LACY_RESPONSE_BODY"
 }

--- a/lib/zsh/execute.zsh
+++ b/lib/zsh/execute.zsh
@@ -358,25 +358,10 @@ lacy_shell_quit() {
     # Run cleanup
     lacy_shell_cleanup
     
-    # Prepare for prompt display if not in ZLE
-    if [[ -z "$ZLE_VERSION" ]]; then
-        print -r -- ""
-    fi
-
-    # Unset aliases
-    unalias ask mode tool spinner quit_lacy quit stop disable_lacy enable_lacy 2>/dev/null
-
-    # Define a `lacy` function so user can re-enter by typing `lacy`
-    local _ldir="$LACY_SHELL_DIR"
-    eval "lacy() {
-        if [[ \$# -eq 0 ]]; then
-            unfunction lacy 2>/dev/null
-            LACY_SHELL_LOADED=false
-            source \"${_ldir}/lacy.plugin.zsh\"
-        else
-            command lacy \"\$@\"
-        fi
-    }"
+    echo ""
+    echo "Lacy Shell deactivated."
+    lacy_print_color 238 "  Type 'lacy on' (or just 'lacy') to re-enter."
+    echo ""
 
     # Restore original prompt
     lacy_shell_restore_prompt

--- a/lib/zsh/execute.zsh
+++ b/lib/zsh/execute.zsh
@@ -2,6 +2,12 @@
 
 # Command execution logic for Lacy Shell
 
+# preexec hook — captures the command typed by the user before it runs.
+# ZSH calls preexec_functions before each user-entered command.
+lacy_shell_preexec() {
+    LACY_LAST_CMD="$1"
+}
+
 # Smart accept-line widget that handles agent queries
 lacy_shell_smart_accept_line() {
     # If Lacy Shell is disabled, use normal accept-line
@@ -131,6 +137,12 @@ lacy_shell_execute_smart_auto() {
 lacy_shell_precmd() {
     # Capture exit code immediately — must be the first line
     local last_exit=$?
+
+    # Log last shell command + exit code (preexec set LACY_LAST_CMD)
+    if [[ -n "$LACY_LAST_CMD" ]]; then
+        lacy_history_log "$LACY_LAST_CMD" "$last_exit"
+        LACY_LAST_CMD=""
+    fi
 
     # Ensure terminal state is clean (safety net for interrupted spinners / agent tools)
     printf '\e[?25h'   # Cursor visible
@@ -319,9 +331,10 @@ lacy_shell_quit() {
     echo "👋 Exiting Lacy Shell..."
     echo ""
     
-    # CRITICAL: Remove precmd hooks FIRST to prevent redrawing
+    # CRITICAL: Remove precmd/preexec hooks FIRST to prevent redrawing
     precmd_functions=(${precmd_functions:#lacy_shell_precmd})
     precmd_functions=(${precmd_functions:#lacy_shell_update_prompt})
+    preexec_functions=(${preexec_functions:#lacy_shell_preexec})
     
     # Disable input interception (only if ZLE is active)
     if [[ -n "$ZLE_VERSION" ]]; then

--- a/lib/zsh/init.zsh
+++ b/lib/zsh/init.zsh
@@ -13,6 +13,7 @@ source "$LACY_SHELL_DIR/lib/core/modes.sh"
 source "$LACY_SHELL_DIR/lib/core/animations.sh"
 source "$LACY_SHELL_DIR/lib/core/spinner.sh"
 source "$LACY_SHELL_DIR/lib/core/mcp.sh"
+source "$LACY_SHELL_DIR/lib/core/render.sh"
 source "$LACY_SHELL_DIR/lib/core/preheat.sh"
 source "$LACY_SHELL_DIR/lib/core/detection.sh"
 

--- a/lib/zsh/init.zsh
+++ b/lib/zsh/init.zsh
@@ -14,6 +14,7 @@ source "$LACY_SHELL_DIR/lib/core/animations.sh"
 source "$LACY_SHELL_DIR/lib/core/spinner.sh"
 source "$LACY_SHELL_DIR/lib/core/mcp.sh"
 source "$LACY_SHELL_DIR/lib/core/render.sh"
+source "$LACY_SHELL_DIR/lib/core/history.sh"
 source "$LACY_SHELL_DIR/lib/core/preheat.sh"
 source "$LACY_SHELL_DIR/lib/core/detection.sh"
 

--- a/lib/zsh/keybindings.zsh
+++ b/lib/zsh/keybindings.zsh
@@ -90,6 +90,45 @@ lacy_shell_line_pre_redraw() {
 # Register the pre-redraw hook
 zle -N zle-line-pre-redraw lacy_shell_line_pre_redraw
 
+# ============================================================================
+# Feature 2: @file Tab completion widget
+#
+# When Tab is pressed and the word under the cursor starts with @,
+# complete it as a filename (stripping the @ for matching, re-adding it
+# when inserting). Falls through to normal ZSH completion otherwise.
+# ============================================================================
+lacy_shell_at_complete_widget() {
+    # Extract the word up to the cursor
+    local before_cursor="${BUFFER[1,$CURSOR]}"
+    local cur_word="${before_cursor##* }"   # last space-delimited token
+
+    if [[ "$cur_word" == @?* ]]; then
+        local prefix="${cur_word#@}"
+        # Expand glob — (N) suppresses error if no match, (f) splits on newline
+        local -a matches
+        matches=( ${(N)~prefix}*(N) )
+
+        if (( ${#matches} == 0 )); then
+            # No matches — fall through to default completion
+            zle expand-or-complete
+        elif (( ${#matches} == 1 )); then
+            # Single match — complete in-place
+            local insert="${matches[1]}"
+            local offset=$(( CURSOR - ${#cur_word} ))
+            BUFFER="${BUFFER[1,$offset]}@${insert}${BUFFER[$(( CURSOR + 1 )),-1]}"
+            CURSOR=$(( offset + ${#insert} + 1 ))
+        else
+            # Multiple matches — list them in dim gray and let user keep typing
+            zle -M "$(printf '\e[38;5;238m  @%s\e[0m\n' "${matches[@]}")"
+        fi
+    else
+        # Default Tab behavior
+        zle expand-or-complete
+    fi
+    zle reset-prompt
+}
+zle -N lacy_shell_at_complete_widget
+
 # Set up all keybindings
 lacy_shell_setup_keybindings() {
     # Only add our custom bindings - don't touch existing terminal shortcuts
@@ -99,6 +138,9 @@ lacy_shell_setup_keybindings() {
 
     # Alternative keybindings
     bindkey '^T' lacy_shell_toggle_mode_widget      # Ctrl+T: Toggle mode (backup)
+
+    # @file Tab completion (overrides default Tab only when word starts with @)
+    bindkey '^I' lacy_shell_at_complete_widget      # Tab: @file-aware completion
 
     # Direct mode switches (Ctrl+X prefix)
     # bindkey '^X^A' lacy_shell_agent_mode_widget     # Ctrl+X Ctrl+A: Agent mode
@@ -367,6 +409,7 @@ lacy_shell_cleanup_keybindings() {
     bindkey '^D' delete-char-or-list
     bindkey '^@' set-mark-command
     bindkey '^T' transpose-chars
+    bindkey '^I' expand-or-complete
 
     # Remove real-time indicator hook
     zle -D zle-line-pre-redraw 2>/dev/null
@@ -374,6 +417,7 @@ lacy_shell_cleanup_keybindings() {
     # Remove custom widgets
     zle -D lacy_shell_toggle_mode_widget 2>/dev/null
     zle -D lacy_shell_delete_char_or_quit_widget 2>/dev/null
+    zle -D lacy_shell_at_complete_widget 2>/dev/null
 }
 
 # Register widgets


### PR DESCRIPTION
## Summary
This PR introduces three major features to Lacy Shell: intelligent response rendering with support for thinking blocks and code diffs, shell command history logging for context enrichment, and a proper activation/deactivation lifecycle that allows users to toggle Lacy on and off without reloading the shell.

## Key Changes

### 1. Response Rendering (`lib/core/render.sh`)
- **Thinking block extraction**: Strips `<thinking>...</thinking>` sections from agent responses and displays them in a bordered box with dim styling
- **Markdown todo rendering**: Converts `- [ ]` to `☐` (dim) and `- [x]` to `☑` (green) outside code blocks
- **Code block and diff highlighting**: 
  - Dims fence markers (` ``` `)
  - Colors diff lines: green for additions, red for removals, cyan for hunk headers
  - Preserves indentation for nested code blocks
- **Line-by-line processing**: Maintains state across multiple lines to track code block boundaries

### 2. History Logging & Context Enrichment (`lib/core/history.sh`)
- **Command logging**: Captures executed commands and exit codes to `conversation.log` with timestamps
- **@file reference expansion**: Parses `@path` tokens in queries, reads file contents (up to 8 KB), and appends them to the query for agent context
  - Strips trailing punctuation (`,.:;!?`) before resolving paths
  - Deduplicates files to avoid including the same file twice
- **Context query building**: Enriches user queries with recent shell command history (last 5 entries) so the agent understands what the user has been doing

### 3. Activation/Deactivation Lifecycle
- **`lacy_shell_activate()`**: New function that safely hooks into the shell (Bash PROMPT_COMMAND or ZSH precmd/preexec) and initializes Lacy
  - Guards against double-activation with a check for `LACY_SHELL_ACTIVE`
  - Captures and restores the original prompt command on cleanup
- **`lacy()` shell function**: Persistent function that survives deactivation and routes commands:
  - `lacy on/start/activate` → activate Lacy
  - `lacy off/stop/deactivate` → deactivate Lacy
  - `lacy` (no args) → show status if active, activate if inactive
  - `lacy <other>` → delegate to CLI binary
- **`LACY_AUTO_START` environment variable**: Allows users to suppress auto-activation by setting `LACY_AUTO_START=false` before sourcing the plugin
- **Improved cleanup**: Deactivation now properly removes hooks, restores original prompt, and displays a helpful message with instructions to re-enter

### 4. ZSH @file Tab Completion (`lib/zsh/keybindings.zsh`)
- **`lacy_shell_at_complete_widget`**: New Tab completion widget that:
  - Detects when the current word starts with `@`
  - Expands glob patterns for file matching
  - Single match: auto-completes in-place
  - Multiple matches: displays them in dim gray for user selection
  - Falls through to default ZSH completion for non-@file words

### 5. Bash History Integration (`lib/bash/execute.bash`)
- **`lacy_shell_precmd_bash()`**: Enhanced to extract and log the last executed command from Bash history
  - Tracks `HISTCMD` to avoid logging the same entry twice
  - Filters out agent queries already handled

### 6. ZSH History Integration (`lib/zsh/execute.zsh`)
- **`lacy_shell_preexec()`**: New hook that captures the command before execution
- **`lacy_shell_precmd()`**: Enhanced to log the captured command and exit code

### 7. Response Rendering Integration (`lib/core/mcp.sh`)
- All agent responses now piped through `lacy_render_response` for consistent formatting
- File expansion feedback shown before spinner starts
- Context query building applied before sending to agent

### 8

https://claude.ai/code/session_01MC5M7cYYuYbd7ATVdGEAtV