### PR TITLE
fix: strip trailing punctuation before agent/reserved word matching

### DIFF
--- a/docs/NATURAL_LANGUAGE_DETECTION.md
+++ b/docs/NATURAL_LANGUAGE_DETECTION.md
@@ -113,6 +113,14 @@ One of:
 
 ---
 
+### Trailing punctuation
+
+Trailing punctuation (`?`, `!`, `.`, `,`, `;`, `:`) is stripped from the first word before matching against agent words and reserved words. This ensures that `why?` routes to the agent just like `why`, and `do?` is recognized as the reserved word `do`.
+
+Punctuation is only stripped for word-list lookups — the original token (with punctuation) is still used for `command -v` checks, so real commands are unaffected.
+
+---
+
 ### Minimum word count
 
 Inputs with fewer than 2 words are always treated as real commands, even if they fail. Single-word inputs are handled by the agent words list (Layer 1) or treated as typos.
@@ -161,6 +169,7 @@ When natural language is detected, silently reroute the input to the agent. No u
 | `cargo ahead with the release`           | `cargo`     | 2     | Runs — "no such command" + "ahead" is NL — reroute              |
 | `RUST_LOG=debug cargo run`               | `RUST_LOG=…`| —     | Env var prefix — `cargo` is valid command — shell               |
 | `FOO=bar BAZ=qux node index.js`         | `FOO=…`     | —     | Multiple env var prefixes — `node` is valid — shell             |
+| `why?`                                   | `why?`→`why`| 1     | Trailing `?` stripped — matches agent word — route to agent     |
 | `ls -la`                                 | `ls`        | —     | Succeeds — no detection                                         |
 | `grep -r foo`                            | `grep`      | —     | May fail but error doesn't match NL heuristic                   |
 

--- a/lib/core/detection.sh
+++ b/lib/core/detection.sh
@@ -123,12 +123,30 @@ lacy_shell_classify_input() {
     fi
 
     # Auto mode: check special cases and commands
-    # Extract first token respecting backslash-escaped spaces (e.g., /path/to/Google\ Chrome)
-    local _esc_input="${input//\\ /$'\x01'}"
-    local first_word="${_esc_input%% *}"
-    first_word="${first_word//$'\x01'/\\ }"
-    # Un-escaped version for command -v lookups (backslash-space → space)
-    local first_word_cmd="${first_word//\\ / }"
+    # Extract first token respecting:
+    #   - backslash-escaped spaces: /path/to/Google\ Chrome
+    #   - double-quoted paths: "/Applications/Google Chrome.app/..."
+    #   - single-quoted paths: '/Applications/Google Chrome.app/...'
+    local first_word first_word_cmd
+    if [[ "$input" == \"* ]]; then
+        # Double-quoted first token: extract up to closing quote
+        local _after="${input#\"}"
+        first_word="\"${_after%%\"*}\""
+        # Strip quotes for command -v lookup
+        first_word_cmd="${_after%%\"*}"
+    elif [[ "$input" == \'* ]]; then
+        # Single-quoted first token: extract up to closing quote
+        local _after="${input#\'}"
+        first_word="'${_after%%\'*}'"
+        first_word_cmd="${_after%%\'*}"
+    else
+        # Backslash-escaped spaces
+        local _esc_input="${input//\\ /$'\x01'}"
+        first_word="${_esc_input%% *}"
+        first_word="${first_word//$'\x01'/\\ }"
+        # Un-escaped version for command -v lookups (backslash-space → space)
+        first_word_cmd="${first_word//\\ / }"
+    fi
     local first_word_lower
     first_word_lower=$(_lacy_lowercase "$first_word_cmd")
 
@@ -222,7 +240,10 @@ lacy_shell_classify_input() {
 
     # Single word that's not a command = probably a typo -> shell
     # Multiple words with non-command first word = natural language -> agent
-    if [[ "$_esc_input" != *" "* ]]; then
+    # Check if there's anything after the first token
+    local _rest_after_first="${input#"$first_word"}"
+    _rest_after_first="${_rest_after_first#"${_rest_after_first%%[^[:space:]]*}"}"
+    if [[ -z "$_rest_after_first" ]]; then
         echo "shell"
     else
         echo "agent"
@@ -341,6 +362,10 @@ lacy_shell_test_detection() {
         # Backslash-escaped spaces in paths
         "/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome --remote-debugging-port=9222"
         "./my\\ script.sh --flag"
+        # Quoted paths with spaces
+        '"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222'
+        "'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' --flag"
+        '"/usr/local/bin/my tool"'
         # @ agent bypass
         "@ make sure the tests pass"
         "@fix the bug in auth"

--- a/lib/core/detection.sh
+++ b/lib/core/detection.sh
@@ -150,9 +150,15 @@ lacy_shell_classify_input() {
     local first_word_lower
     first_word_lower=$(_lacy_lowercase "$first_word_cmd")
 
+    # Strip trailing punctuation for word-list lookups (e.g., "why?" → "why")
+    local first_word_stripped="$first_word_lower"
+    while [[ -n "$first_word_stripped" && "$first_word_stripped" == *[?.,\;:!] ]]; do
+        first_word_stripped="${first_word_stripped%?}"
+    done
+
     # Layer 1a: Shell reserved words pass `command -v` but are never valid
     # standalone commands. Route to agent. (see docs/NATURAL_LANGUAGE_DETECTION.md)
-    if _lacy_in_list "$first_word_lower" "${LACY_SHELL_RESERVED_WORDS[@]}"; then
+    if _lacy_in_list "$first_word_stripped" "${LACY_SHELL_RESERVED_WORDS[@]}"; then
         echo "agent"
         return
     fi
@@ -164,7 +170,7 @@ lacy_shell_classify_input() {
     # argument (after flags/paths/numbers) that is not an NL marker.
     # Examples: `which python` → shell, `yes | cmd` → shell
     #           `which version to use` → agent, `yes lets go` → agent
-    if _lacy_in_list "$first_word_lower" "${LACY_AGENT_WORDS[@]}"; then
+    if _lacy_in_list "$first_word_stripped" "${LACY_AGENT_WORDS[@]}"; then
         if lacy_shell_is_valid_command "$first_word_cmd"; then
             # Shell operators anywhere → shell
             local _op

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -113,6 +113,14 @@ assert_eq "how → agent" "agent" "$(lacy_shell_classify_input 'how')"
 assert_eq "no → agent" "agent" "$(lacy_shell_classify_input 'no')"
 assert_eq "nope → agent" "agent" "$(lacy_shell_classify_input 'nope')"
 
+# Agent words — with trailing punctuation
+assert_eq "why? → agent" "agent" "$(lacy_shell_classify_input 'why?')"
+assert_eq "how? → agent" "agent" "$(lacy_shell_classify_input 'how?')"
+assert_eq "no! → agent" "agent" "$(lacy_shell_classify_input 'no!')"
+assert_eq "yes. → agent" "agent" "$(lacy_shell_classify_input 'yes.')"
+assert_eq "sure! → agent" "agent" "$(lacy_shell_classify_input 'sure!')"
+assert_eq "do? → agent" "agent" "$(lacy_shell_classify_input 'do?')"
+
 # Agent words — multi-word
 assert_eq "what is this → agent" "agent" "$(lacy_shell_classify_input 'what is this')"
 assert_eq "yes lets go → agent" "agent" "$(lacy_shell_classify_input 'yes lets go')"


### PR DESCRIPTION
## Summary
- **Bug:** typing `why?` routed to shell instead of agent because the trailing `?` caused an exact-match failure against `LACY_AGENT_WORDS`
- **Fix:** strip trailing punctuation (`? ! . , ; :`) from the first word before agent-word and reserved-word lookups; original token preserved for `command -v` checks
- Added 6 test cases (`why?`, `how?`, `no!`, `yes.`, `sure!`, `do?`)
- Documented in `NATURAL_LANGUAGE_DETECTION.md`

## Test plan
- [x] All 98 tests pass (`bash tests/test_core.sh`)
- [ ] Manual: type `why?` in auto mode → routes to agent
- [ ] Manual: type `ls` still routes to shell (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)