### PR TITLE
feat: terminal output capture via Kitty/WezTerm APIs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,15 +121,25 @@ Minimum 2 words required. See `docs/NATURAL_LANGUAGE_DETECTION.md` for full algo
 
 **File:** `lib/core/context.sh`
 
-Prepends delta-based terminal context (cwd, git branch, exit code, recent commands) to agent queries. Only includes what changed since the last query — zero overhead when nothing changed.
+Prepends delta-based terminal context (cwd, git branch, exit code, recent commands, terminal output) to agent queries. Only includes what changed since the last query — zero overhead when nothing changed.
 
 **Format:** `[cwd: /path] [git: branch] [exit: 1] [recent: cmd1 | cmd2] <query>`
+
+**With terminal output** (Kitty/WezTerm):
+```
+[cwd: /path] [exit: 1] [recent: npm test]
+[terminal-output]
+npm ERR! Test failed. See above for more details.
+[/terminal-output]
+why did that fail?
+```
 
 **Delta tracking:**
 
 - CWD and git branch: compared against last-sent values, skipped if unchanged. Detached HEAD shows short commit hash instead of literal "HEAD"
 - Exit code: only included when non-zero AND a shell command ran since the last query
 - Recent commands: explicit ring buffer (max 10), not `fc`/`history` (avoids agent queries leaking)
+- Terminal output: lazy screen capture via terminal API at query time (Kitty, WezTerm). Stripped of ANSI escapes, capped at 50 lines (configurable via `context.output_lines`). Skipped inside tmux/screen.
 - Counters reset after each agent query — next query starts fresh
 
 **Hook chain:**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The first word of your input is also syntax-highlighted in real-time: **green** 
 
 **Smart rerouting** (auto mode): When a valid command contains natural language patterns (3+ bare words with articles, pronouns, etc.) and fails, lacy shows a hint and automatically re-sends it to the AI agent. Shell reserved words like `do`, `then`, `in`, `else` are routed directly to the agent — they pass `command -v` but are never standalone commands.
 
-**Terminal context**: When you ask the AI a question, lacy automatically includes your current directory, git branch, recent commands, and exit codes — but only what changed since your last query. Ask "why did that fail?" and the agent already knows what you ran.
+**Terminal context**: When you ask the AI a question, lacy automatically includes your current directory, git branch, recent commands, and exit codes — but only what changed since your last query. In supported terminals (Kitty, WezTerm), it also captures the visible screen output. Ask "why did that fail?" and the agent sees the error message.
 
 ## Modes
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -47,8 +47,16 @@ Agent queries include delta-based terminal context (cwd, git branch, exit code, 
 | `[git: branch]` | Git branch changed since last query |
 | `[exit: N]` | Last command exited non-zero AND a command ran since last query |
 | `[recent: cmd1 \| cmd2]` | Shell commands were run between queries (max 10, truncated at 80 chars) |
+| `[terminal-output]...[/terminal-output]` | Terminal screen capture (Kitty, WezTerm only — max 50 lines, ANSI stripped) |
 
-Recent commands use an explicit buffer — not shell history — to avoid agent queries appearing in the context. Counters reset after each agent query. `/new` resets all context state.
+Recent commands use an explicit buffer — not shell history — to avoid agent queries appearing in the context. Terminal output is captured lazily at query time via terminal emulator APIs (no execution overhead). Counters reset after each agent query. `/new` resets all context state.
+
+Configure via `~/.lacy/config.yaml`:
+```yaml
+context:
+  output: true          # Enable terminal screen capture (default: true)
+  output_lines: 50      # Max lines to include (default: 50)
+```
 
 ---
 

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -95,6 +95,7 @@ lacy_shell_load_config() {
         local agent_map="command:LACY_SHELL_AGENT_COMMAND,context_mode:LACY_SHELL_AGENT_CONTEXT_MODE,needs_api_keys:LACY_SHELL_AGENT_NEEDS_API_KEYS"
         local agent_tools_map="active:LACY_ACTIVE_TOOL,custom_command:LACY_CUSTOM_TOOL_CMD"
         local preheat_map="eager:LACY_PREHEAT_EAGER,server_port:LACY_PREHEAT_SERVER_PORT"
+        local context_map="output:_LACY_CTX_OUTPUT_ENABLED,output_lines:_LACY_CTX_OUTPUT_MAX_LINES"
 
         # Track current section
         local current_section=""
@@ -113,6 +114,9 @@ lacy_shell_load_config() {
                 continue
             elif [[ "$line" =~ ^preheat: ]]; then
                 current_section="preheat"
+                continue
+            elif [[ "$line" =~ ^context: ]]; then
+                current_section="context"
                 continue
             elif [[ "$line" =~ ^agent: ]]; then
                 current_section="agent"
@@ -149,6 +153,9 @@ lacy_shell_load_config() {
                     "preheat")
                         lacy_shell_export_config_value "$key" "$value" "$preheat_map"
                         ;;
+                    "context")
+                        lacy_shell_export_config_value "$key" "$value" "$context_map"
+                        ;;
                 esac
             fi
         done < "$LACY_SHELL_CONFIG_FILE"
@@ -178,6 +185,8 @@ lacy_shell_load_config() {
             printf 'LACY_CUSTOM_TOOL_CMD=%q\n' "$LACY_CUSTOM_TOOL_CMD"
             printf 'LACY_SHELL_MCP_SERVERS=%q\n' "$LACY_SHELL_MCP_SERVERS"
             printf 'LACY_SHELL_MCP_SERVERS_JSON=%q\n' "$LACY_SHELL_MCP_SERVERS_JSON"
+            printf '_LACY_CTX_OUTPUT_ENABLED=%q\n' "${_LACY_CTX_OUTPUT_ENABLED:-true}"
+            printf '_LACY_CTX_OUTPUT_MAX_LINES=%q\n' "${_LACY_CTX_OUTPUT_MAX_LINES:-50}"
         } > "$LACY_SHELL_CONFIG_CACHE_FILE"
 
         LACY_CONFIG_CACHE_VALID=true
@@ -274,6 +283,11 @@ agent_tools:
 # preheat:
 #   eager: false          # Start background server on plugin load
 #   server_port: 4096     # Port for background server
+
+# Terminal context: output capture from supported terminals (Kitty, WezTerm)
+# context:
+#   output: true          # Capture terminal screen at query time
+#   output_lines: 50      # Max lines to include (truncates from top)
 
 # Agent CLI configuration (legacy)
 # Configure which CLI tool to use for AI queries

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -336,3 +336,15 @@ _lacy_jobctl_on() {
         LACY_JOBCTL_WAS_SET=""
     fi
 }
+
+# Escape a string for safe JSON embedding — handles \, ", and control chars.
+# Usage: escaped=$(_lacy_json_escape_str "$value")
+_lacy_json_escape_str() {
+    local s="$1"
+    s="${s//\\/\\\\}"   # \ → \\
+    s="${s//\"/\\\"}"   # " → \"
+    s="${s//$'\n'/\\n}" # newline → \n
+    s="${s//$'\r'/\\r}" # carriage return → \r
+    s="${s//$'\t'/\\t}" # tab → \t
+    printf '%s' "$s"
+}

--- a/lib/core/context.sh
+++ b/lib/core/context.sh
@@ -4,7 +4,7 @@
 # Only sends what changed since the last agent query.
 # Shared across Bash 4+ and ZSH.
 
-# === State ===
+# === State: Delta Tracking ===
 _LACY_CTX_LAST_CWD=""
 _LACY_CTX_LAST_GIT=""
 _LACY_CTX_CMDS_SINCE_QUERY=0
@@ -14,6 +14,78 @@ _LACY_CTX_REAL_CMD=false
 # Command ring buffer — explicit array avoids agent queries leaking from fc/history
 _LACY_CTX_CMD_BUFFER=()
 _LACY_CTX_CMD_BUFFER_MAX=10
+
+# === State: Terminal Output Capture ===
+_LACY_CTX_TERMINAL_CAPTURE_CMD=""   # Detected at load time; empty = unsupported
+_LACY_CTX_OUTPUT_ENABLED=true       # Toggled via config (context.output)
+_LACY_CTX_OUTPUT_MAX_LINES=50       # Configurable cap (context.output_lines)
+
+# ============================================================================
+# Terminal Detection (called once at source time)
+# ============================================================================
+
+# Detect terminal emulator API for screen capture.
+# Sets _LACY_CTX_TERMINAL_CAPTURE_CMD to a command string, or empty if unsupported.
+_lacy_ctx_detect_terminal() {
+    _LACY_CTX_TERMINAL_CAPTURE_CMD=""
+
+    # Skip inside tmux/screen — terminal APIs return wrong content
+    [[ -n "${TMUX:-}" ]] && return
+    [[ -n "${STY:-}" ]] && return
+
+    # Kitty: remote control API
+    if [[ -n "${KITTY_PID:-}" ]] || [[ "${TERM_PROGRAM:-}" == "kitty" ]]; then
+        if command -v kitty >/dev/null 2>&1; then
+            _LACY_CTX_TERMINAL_CAPTURE_CMD="kitty @ get-text --extent=screen"
+            return
+        fi
+    fi
+
+    # WezTerm: CLI API
+    if [[ -n "${WEZTERM_EXECUTABLE:-}" ]] || [[ "${TERM_PROGRAM:-}" == "WezTerm" ]]; then
+        if command -v wezterm >/dev/null 2>&1; then
+            _LACY_CTX_TERMINAL_CAPTURE_CMD="wezterm cli get-text"
+            return
+        fi
+    fi
+}
+
+# ============================================================================
+# Screen Capture (called lazily at query time)
+# ============================================================================
+
+# Capture visible terminal screen text, stripped of ANSI escapes.
+# Returns captured text on stdout, or empty if unavailable/disabled.
+_lacy_ctx_capture_screen() {
+    [[ "$_LACY_CTX_OUTPUT_ENABLED" != true ]] && return
+    [[ -z "$_LACY_CTX_TERMINAL_CAPTURE_CMD" ]] && return
+
+    local raw_output
+    raw_output=$(eval "$_LACY_CTX_TERMINAL_CAPTURE_CMD" 2>/dev/null) || return
+
+    # Strip ANSI escape sequences (SGR, cursor movement, etc.)
+    local cleaned
+    cleaned=$(printf '%s\n' "$raw_output" | sed $'s/\x1b\[[0-9;]*[a-zA-Z]//g')
+
+    # Remove trailing blank lines
+    while [[ "$cleaned" == *$'\n' ]]; do
+        cleaned="${cleaned%$'\n'}"
+    done
+
+    [[ -z "$cleaned" ]] && return
+
+    # Truncate from the top, keeping the last N lines (errors are at the bottom)
+    local max_lines="${_LACY_CTX_OUTPUT_MAX_LINES:-50}"
+    if (( max_lines > 0 )); then
+        local line_count
+        line_count=$(printf '%s\n' "$cleaned" | wc -l)
+        if (( line_count > max_lines )); then
+            cleaned=$(printf '%s\n' "$cleaned" | tail -n "$max_lines")
+        fi
+    fi
+
+    printf '%s' "$cleaned"
+}
 
 # ============================================================================
 # Hooks (called from accept-line and precmd)
@@ -53,6 +125,7 @@ _lacy_ctx_on_precmd() {
 # Sets _LACY_CTX_RESULT to the enriched query (avoids subshell so state resets
 # propagate to the parent). If nothing changed, result is the bare query.
 # Format: [cwd: /path] [git: branch] [exit: 1] [recent: cmd1 | cmd2] query
+# With output: ...context header...\n[terminal-output]\n...\n[/terminal-output]\nquery
 # Usage: _lacy_build_query_context "$query"; query="$_LACY_CTX_RESULT"
 _LACY_CTX_RESULT=""
 
@@ -106,13 +179,27 @@ _lacy_build_query_context() {
         ctx+="[recent: ${cmds}] "
     fi
 
+    # --- Terminal screen output (lazy capture, only if commands ran) ---
+    local screen_output=""
+    if (( _LACY_CTX_CMDS_SINCE_QUERY > 0 )); then
+        screen_output=$(_lacy_ctx_capture_screen)
+    fi
+
     # --- Reset counters ---
     _LACY_CTX_CMDS_SINCE_QUERY=0
     _LACY_CTX_LAST_EXIT_CODE=0
     _LACY_CTX_CMD_BUFFER=()
 
     # --- Set result ---
-    _LACY_CTX_RESULT="${ctx}${query}"
+    if [[ -n "$screen_output" ]]; then
+        _LACY_CTX_RESULT="${ctx}
+[terminal-output]
+${screen_output}
+[/terminal-output]
+${query}"
+    else
+        _LACY_CTX_RESULT="${ctx}${query}"
+    fi
 }
 
 # ============================================================================
@@ -120,6 +207,7 @@ _lacy_build_query_context() {
 # ============================================================================
 
 # Clear all context state so the next query sends full context.
+# Does NOT reset terminal detection or config — those are session-lifetime.
 _lacy_ctx_reset() {
     _LACY_CTX_LAST_CWD=""
     _LACY_CTX_LAST_GIT=""
@@ -128,3 +216,9 @@ _lacy_ctx_reset() {
     _LACY_CTX_REAL_CMD=false
     _LACY_CTX_CMD_BUFFER=()
 }
+
+# ============================================================================
+# Init (runs once when sourced)
+# ============================================================================
+
+_lacy_ctx_detect_terminal

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -669,7 +669,7 @@ lacy_shell_query_openai() {
     local input_file="$1"
     local api_key="$2"
     local content
-    content=$(cat "$input_file" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | tr '\n' ' ')
+    content=$(_lacy_json_escape_str "$(cat "$input_file")")
 
     local response
     response=$(curl -s -H "Content-Type: application/json" \
@@ -684,7 +684,7 @@ lacy_shell_query_anthropic() {
     local input_file="$1"
     local api_key="$2"
     local content
-    content=$(cat "$input_file" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | tr '\n' ' ')
+    content=$(_lacy_json_escape_str "$(cat "$input_file")")
 
     local response
     response=$(curl -s -H "Content-Type: application/json" \

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -149,7 +149,7 @@ lacy_preheat_server_query() {
     fi
 
     local escaped_query
-    escaped_query=$(printf '%s' "$query" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\t/\\t/g' | tr '\n' ' ')
+    escaped_query=$(_lacy_json_escape_str "$query")
 
     # Pass the current working directory on every message request.
     # lash/opencode wraps each request in Instance.provide({ directory }) so

--- a/lib/core/telemetry.sh
+++ b/lib/core/telemetry.sh
@@ -8,17 +8,15 @@ readonly _LACY_UMAMI_URL="${LACY_UMAMI_URL:-https://analytics.lacy.sh}"
 readonly _LACY_UMAMI_WEBSITE_ID="${LACY_UMAMI_WEBSITE_ID:-577521d7-3db7-4a77-a45c-3c97f21b5322}"
 readonly _LACY_TELEMETRY_FLAG="${LACY_SHELL_HOME}/.telemetry_sent"
 
-# Escape a string for safe JSON embedding — handles \, ", and control chars.
-# Usage: escaped=$(_lacy_json_escape_str "$value")
-_lacy_json_escape_str() {
-    local s="$1"
-    s="${s//\\/\\\\}"   # \ → \\
-    s="${s//\"/\\\"}"   # " → \"
-    s="${s//$'\n'/\\n}" # newline → \n
-    s="${s//$'\r'/\\r}" # carriage return → \r
-    s="${s//$'\t'/\\t}" # tab → \t
-    printf '%s' "$s"
-}
+# _lacy_json_escape_str is defined in constants.sh (shared helper).
+# Guard: define here only if not already available (e.g., standalone sourcing).
+if ! command -v _lacy_json_escape_str >/dev/null 2>&1; then
+    _lacy_json_escape_str() {
+        local s="$1"
+        s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/\\n}"; s="${s//$'\r'/\\r}"; s="${s//$'\t'/\\t}"
+        printf '%s' "$s"
+    }
+fi
 
 # Send a tracking event to Umami (background, fail-silent)
 _lacy_track_event() {

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -417,6 +417,70 @@ if [[ "$_current_branch" != "HEAD" ]]; then
 fi
 
 # ============================================================================
+# Terminal Output Context Tests
+# ============================================================================
+
+echo ""
+echo "--- Context: terminal output capture ---"
+
+# Save original state
+_saved_capture_cmd="$_LACY_CTX_TERMINAL_CAPTURE_CMD"
+_saved_output_enabled="$_LACY_CTX_OUTPUT_ENABLED"
+
+# In test environment, no terminal emulator API is available
+assert_eq "no capture cmd in test env" "" "$_saved_capture_cmd"
+
+# Without capture cmd, no output block in context
+_LACY_CTX_TERMINAL_CAPTURE_CMD=""
+_LACY_CTX_OUTPUT_ENABLED=true
+_lacy_ctx_reset
+_lacy_ctx_mark_command "npm test"
+_lacy_ctx_on_precmd 1
+_lacy_build_query_context "why fail"
+result="$_LACY_CTX_RESULT"
+assert_true "no output block without capture" _str_not_contains "$result" "[terminal-output]"
+
+# Simulate capture by setting the variable to echo
+_LACY_CTX_TERMINAL_CAPTURE_CMD="echo 'Error: test failed'"
+_LACY_CTX_OUTPUT_ENABLED=true
+_lacy_ctx_reset
+# Burn cwd delta
+_lacy_build_query_context "burn"
+_lacy_ctx_mark_command "npm test"
+_lacy_ctx_on_precmd 1
+_lacy_build_query_context "why fail"
+result="$_LACY_CTX_RESULT"
+assert_true "output block present with capture" _str_contains "$result" "[terminal-output]"
+assert_true "output content present" _str_contains "$result" "Error: test failed"
+assert_true "output block closed" _str_contains "$result" "[/terminal-output]"
+
+# Disabled via config
+_LACY_CTX_OUTPUT_ENABLED=false
+_lacy_ctx_mark_command "npm test"
+_lacy_ctx_on_precmd 1
+_lacy_build_query_context "why fail disabled"
+result="$_LACY_CTX_RESULT"
+assert_true "no output when disabled" _str_not_contains "$result" "[terminal-output]"
+
+# No capture when no commands ran
+_LACY_CTX_OUTPUT_ENABLED=true
+_LACY_CTX_TERMINAL_CAPTURE_CMD="echo 'should not appear'"
+_lacy_ctx_reset
+_lacy_build_query_context "burn"
+_lacy_build_query_context "no commands ran"
+result="$_LACY_CTX_RESULT"
+assert_true "no output when no commands ran" _str_not_contains "$result" "[terminal-output]"
+
+# JSON escape helper
+assert_eq "json escape newlines" 'hello\nworld' "$(_lacy_json_escape_str $'hello\nworld')"
+assert_eq "json escape quotes" 'say \"hi\"' "$(_lacy_json_escape_str 'say "hi"')"
+assert_eq "json escape backslash" 'path\\to' "$(_lacy_json_escape_str 'path\to')"
+
+# Restore original state
+_LACY_CTX_TERMINAL_CAPTURE_CMD="$_saved_capture_cmd"
+_LACY_CTX_OUTPUT_ENABLED="$_saved_output_enabled"
+
+# ============================================================================
 # Results
 # ============================================================================
 


### PR DESCRIPTION
## Summary

- Captures visible terminal screen output and includes it in agent queries
- Uses terminal emulator APIs (Kitty, WezTerm) — zero execution overhead, no command wrapping
- Fixes newline escaping bug in lash/opencode server path (`tr '\n' ' '` → `_lacy_json_escape_str`)
- Configurable via `context.output` and `context.output_lines` in config.yaml

## How it works

1. User runs `npm test` → fails with error output visible on screen
2. User types "why did that fail?"
3. At query time, lacy calls `kitty @ get-text --extent=screen` to grab the visible terminal
4. Output is stripped of ANSI codes, truncated to 50 lines, and included in context

```
[cwd: /project] [exit: 1] [recent: npm test]
[terminal-output]
npm ERR! Test failed. See above for more details.
npm ERR! Exit code: 1
[/terminal-output]
why did that fail?
```

## Design

| Decision | Rationale |
|----------|-----------|
| Lazy capture at query time | Zero overhead during command execution |
| Terminal emulator APIs | No wrapping, no breakage of interactive programs |
| Skip inside tmux/screen | Terminal APIs return wrong content in multiplexers |
| Default ON | Zero-config intelligence — the point of lacy |
| ANSI stripping | AI agents parse text, not escape codes |
| `_lacy_json_escape_str` shared helper | Fixes newline destruction in server path, reusable |

## Supported terminals

| Terminal | API | Status |
|----------|-----|--------|
| Kitty | `kitty @ get-text --extent=screen` | Supported (requires `allow_remote_control`) |
| WezTerm | `wezterm cli get-text` | Supported |
| iTerm2 | — | No public capture API |
| Terminal.app | — | No capture API |
| Alacritty | — | No capture API |

Unsupported terminals gracefully fall back to Phase 1 context (history, exit codes, cwd, git).

## Files changed

- `lib/core/context.sh` — terminal detection, screen capture, output block in context builder
- `lib/core/constants.sh` — `_lacy_json_escape_str` shared helper (moved from telemetry.sh)
- `lib/core/telemetry.sh` — guard against redefinition
- `lib/core/preheat.sh` — fixed newline escaping in server query path
- `lib/core/mcp.sh` — fixed newline escaping in API fallback paths
- `lib/core/config.sh` — `context:` config section (output, output_lines)
- Docs: `CLAUDE.md`, `README.md`, `docs/DOCS.md`
- Tests: 9 new tests (122 total, all pass in Bash + ZSH)

## Test plan

- [x] `bash tests/test_core.sh` — 122/122 pass
- [x] `zsh tests/test_core.sh` — 122/122 pass
- [ ] Manual test in Kitty: run failing command, query agent, verify output in context
- [ ] Verify tmux detection skips capture correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)