### PR TITLE
Remove Kitty and WezTerm terminal support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Prepends delta-based terminal context (cwd, git branch, exit code, recent comman
 
 **Format:** `[cwd: /path] [git: branch] [exit: 1] [recent: cmd1 | cmd2] <query>`
 
-**With terminal output** (tmux, screen, Kitty, WezTerm, iTerm2, Terminal.app):
+**With terminal output** (tmux, screen, iTerm2, Terminal.app):
 ```
 [cwd: /path] [exit: 1] [recent: npm test]
 [terminal-output]
@@ -139,7 +139,7 @@ why did that fail?
 - CWD and git branch: compared against last-sent values, skipped if unchanged. Detached HEAD shows short commit hash instead of literal "HEAD"
 - Exit code: only included when non-zero AND a shell command ran since the last query
 - Recent commands: explicit ring buffer (max 10), not `fc`/`history` (avoids agent queries leaking)
-- Terminal output: lazy screen capture via terminal/multiplexer API at query time (tmux, screen, Kitty, WezTerm, iTerm2, Terminal.app). Stripped of ANSI escapes, capped at 50 lines (configurable via `context.output_lines`). tmux/screen checked first since terminal emulator APIs return wrong content inside multiplexers.
+- Terminal output: lazy screen capture via terminal/multiplexer API at query time (tmux, screen, iTerm2, Terminal.app). Stripped of ANSI escapes, capped at 50 lines (configurable via `context.output_lines`). tmux/screen checked first since terminal emulator APIs return wrong content inside multiplexers.
 - Counters reset after each agent query — next query starts fresh
 
 **Hook chain:**

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The first word of your input is also syntax-highlighted in real-time: **green** 
 
 **Smart rerouting** (auto mode): When a valid command contains natural language patterns (3+ bare words with articles, pronouns, etc.) and fails, lacy shows a hint and automatically re-sends it to the AI agent. Shell reserved words like `do`, `then`, `in`, `else` are routed directly to the agent — they pass `command -v` but are never standalone commands.
 
-**Terminal context**: When you ask the AI a question, lacy automatically includes your current directory, git branch, recent commands, and exit codes, but only what changed since your last query. In supported terminals (tmux, screen, Kitty, WezTerm, iTerm2, Terminal.app), it also captures the visible screen output so the agent can see error messages and stack traces.
+**Terminal context**: When you ask the AI a question, lacy automatically includes your current directory, git branch, recent commands, and exit codes, but only what changed since your last query. In supported terminals (tmux, screen, iTerm2, Terminal.app), it also captures the visible screen output so the agent can see error messages and stack traces.
 
 ## Modes
 

--- a/docs/DOCS.md
+++ b/docs/DOCS.md
@@ -47,7 +47,7 @@ Agent queries include delta-based terminal context (cwd, git branch, exit code, 
 | `[git: branch]` | Git branch changed since last query |
 | `[exit: N]` | Last command exited non-zero AND a command ran since last query |
 | `[recent: cmd1 \| cmd2]` | Shell commands were run between queries (max 10, truncated at 80 chars) |
-| `[terminal-output]...[/terminal-output]` | Terminal screen capture (tmux, screen, Kitty, WezTerm, iTerm2, Terminal.app, max 50 lines, ANSI stripped) |
+| `[terminal-output]...[/terminal-output]` | Terminal screen capture (tmux, screen, iTerm2, Terminal.app, max 50 lines, ANSI stripped) |
 
 Recent commands use an explicit buffer (not shell history) to avoid agent queries appearing in the context. Terminal output is captured lazily at query time via multiplexer or terminal emulator APIs (no execution overhead). tmux and screen are detected first since terminal emulator APIs return wrong content inside multiplexers. On macOS, iTerm2 and Terminal.app are supported via AppleScript. Counters reset after each agent query. `/new` resets all context state.
 

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -284,7 +284,7 @@ agent_tools:
 #   eager: false          # Start background server on plugin load
 #   server_port: 4096     # Port for background server
 
-# Terminal context: output capture (tmux, screen, Kitty, WezTerm, iTerm2, Terminal.app)
+# Terminal context: output capture (tmux, screen, iTerm2, Terminal.app)
 # context:
 #   output: true          # Capture terminal screen at query time
 #   output_lines: 50      # Max lines to include (truncates from top)

--- a/lib/core/context.sh
+++ b/lib/core/context.sh
@@ -28,7 +28,7 @@ _LACY_CTX_OUTPUT_MAX_LINES=50       # Configurable cap (context.output_lines)
 # Sets _LACY_CTX_TERMINAL_CAPTURE_CMD to a command string (or function name),
 # or empty if unsupported. Checked once at source time.
 #
-# Priority: tmux > screen > Kitty > WezTerm > iTerm2 > Terminal.app
+# Priority: tmux > screen > iTerm2 > Terminal.app
 # Multiplexers are checked first because terminal emulator APIs return wrong
 # content when running inside a multiplexer.
 _lacy_ctx_detect_terminal() {
@@ -50,23 +50,7 @@ _lacy_ctx_detect_terminal() {
         fi
     fi
 
-    # 3. Kitty: remote control API
-    if [[ -n "${KITTY_PID:-}" ]] || [[ "${TERM_PROGRAM:-}" == "kitty" ]]; then
-        if command -v kitty >/dev/null 2>&1; then
-            _LACY_CTX_TERMINAL_CAPTURE_CMD="kitty @ get-text --extent=screen"
-            return
-        fi
-    fi
-
-    # 4. WezTerm: CLI API
-    if [[ -n "${WEZTERM_EXECUTABLE:-}" ]] || [[ "${TERM_PROGRAM:-}" == "WezTerm" ]]; then
-        if command -v wezterm >/dev/null 2>&1; then
-            _LACY_CTX_TERMINAL_CAPTURE_CMD="wezterm cli get-text"
-            return
-        fi
-    fi
-
-    # 5-6. macOS: AppleScript for iTerm2 and Terminal.app
+    # 3-4. macOS: AppleScript for iTerm2 and Terminal.app
     if [[ "$(uname -s 2>/dev/null)" == "Darwin" ]]; then
         if [[ "${TERM_PROGRAM:-}" == "iTerm.app" ]]; then
             _LACY_CTX_TERMINAL_CAPTURE_CMD="_lacy_ctx_iterm2_capture"

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -483,12 +483,10 @@ echo "--- Context: terminal detection ---"
 # Save env vars we'll be modifying
 _saved_TMUX="${TMUX:-}"
 _saved_STY="${STY:-}"
-_saved_KITTY_PID="${KITTY_PID:-}"
 _saved_TERM_PROGRAM="${TERM_PROGRAM:-}"
-_saved_WEZTERM_EXECUTABLE="${WEZTERM_EXECUTABLE:-}"
 
 # Clean slate for detection tests
-unset TMUX STY KITTY_PID TERM_PROGRAM WEZTERM_EXECUTABLE 2>/dev/null
+unset TMUX STY TERM_PROGRAM 2>/dev/null
 
 # tmux detection: set TMUX, verify capture command
 TMUX="/tmp/tmux-test/default,12345,0"
@@ -501,13 +499,6 @@ STY="12345.pts-0.host"
 _lacy_ctx_detect_terminal
 assert_eq "screen detected" "_lacy_ctx_screen_capture" "$_LACY_CTX_TERMINAL_CAPTURE_CMD"
 unset STY
-
-# tmux takes priority over Kitty
-TMUX="/tmp/tmux-test/default,12345,0"
-KITTY_PID="99999"
-_lacy_ctx_detect_terminal
-assert_eq "tmux beats kitty" "tmux capture-pane -p" "$_LACY_CTX_TERMINAL_CAPTURE_CMD"
-unset TMUX KITTY_PID
 
 # tmux takes priority over screen
 TMUX="/tmp/tmux-test/default,12345,0"
@@ -550,9 +541,7 @@ unset -f _lacy_test_capture_func
 # Restore env vars
 TMUX="$_saved_TMUX"; [[ -z "$TMUX" ]] && unset TMUX 2>/dev/null
 STY="$_saved_STY"; [[ -z "$STY" ]] && unset STY 2>/dev/null
-KITTY_PID="$_saved_KITTY_PID"; [[ -z "$KITTY_PID" ]] && unset KITTY_PID 2>/dev/null
 TERM_PROGRAM="$_saved_TERM_PROGRAM"; [[ -z "$TERM_PROGRAM" ]] && unset TERM_PROGRAM 2>/dev/null
-WEZTERM_EXECUTABLE="$_saved_WEZTERM_EXECUTABLE"; [[ -z "$WEZTERM_EXECUTABLE" ]] && unset WEZTERM_EXECUTABLE 2>/dev/null
 
 # Restore original state
 _LACY_CTX_TERMINAL_CAPTURE_CMD="$_saved_capture_cmd"


### PR DESCRIPTION
## Summary

- Removes Kitty and WezTerm from terminal screen capture detection in `lib/core/context.sh`
- Updates config comments, README, CLAUDE.md, and docs to reflect supported terminals
- Removes related tests

Supported capture backends after this change: tmux, screen, iTerm2, Terminal.app.

These terminals are not in use and we have no way to test the integration.