### PR TITLE
fix: route path-prefixed commands to shell, preserve backslashes in history

### DIFF
--- a/lib/core/detection.sh
+++ b/lib/core/detection.sh
@@ -122,15 +122,6 @@ lacy_shell_classify_input() {
         return
     fi
 
-    # Auto mode: executable path prefixes (/..., ./..., ../..., ~/...) always
-    # route to shell. Handles paths with backslash-escaped spaces (e.g.,
-    # /Applications/Google\ Chrome.app/...) without relying on the
-    # backslash-space substitution below, which behaves differently in ZSH vs Bash.
-    if [[ "$input" == /* || "$input" == ./* || "$input" == ../* || "$input" == '~/'* ]]; then
-        echo "shell"
-        return
-    fi
-
     # Auto mode: check special cases and commands
     # Extract first token respecting:
     #   - backslash-escaped spaces: /path/to/Google\ Chrome
@@ -149,10 +140,14 @@ lacy_shell_classify_input() {
         first_word="'${_after%%\'*}'"
         first_word_cmd="${_after%%\'*}"
     else
-        # Backslash-escaped spaces
-        local _esc_input="${input//\\ /$'\x01'}"
+        # Backslash-escaped spaces: use a variable for the placeholder so that
+        # $'\x01' is processed by ANSI-C quoting at assignment time. In ZSH,
+        # $'\x01' inside ${var//pattern/replacement} is NOT expanded — it is
+        # treated as the literal 6-char string $'\x01', breaking the round-trip.
+        local _lacy_bsp=$'\x01'
+        local _esc_input="${input//\\ /$_lacy_bsp}"
         first_word="${_esc_input%% *}"
-        first_word="${first_word//$'\x01'/\\ }"
+        first_word="${first_word//$_lacy_bsp/\\ }"
         # Un-escaped version for command -v lookups (backslash-space → space)
         first_word_cmd="${first_word//\\ / }"
     fi

--- a/lib/core/detection.sh
+++ b/lib/core/detection.sh
@@ -122,6 +122,15 @@ lacy_shell_classify_input() {
         return
     fi
 
+    # Auto mode: executable path prefixes (/..., ./..., ../..., ~/...) always
+    # route to shell. Handles paths with backslash-escaped spaces (e.g.,
+    # /Applications/Google\ Chrome.app/...) without relying on the
+    # backslash-space substitution below, which behaves differently in ZSH vs Bash.
+    if [[ "$input" == /* || "$input" == ./* || "$input" == ../* || "$input" == '~/'* ]]; then
+        echo "shell"
+        return
+    fi
+
     # Auto mode: check special cases and commands
     # Extract first token respecting:
     #   - backslash-escaped spaces: /path/to/Google\ Chrome

--- a/lib/zsh/execute.zsh
+++ b/lib/zsh/execute.zsh
@@ -27,7 +27,8 @@ lacy_shell_smart_accept_line() {
     _slashcmd="${_slashcmd#"${_slashcmd%%[^[:space:]]*}"}"
     case "$_slashcmd" in
         /new|/reset|/clear|/resume)
-            print -s -- "$input"
+            local _slash_hist="${input//\\/\\\\}"
+            print -s -- "$_slash_hist"
             fc -AI 2>/dev/null
             if [[ "$_slashcmd" == "/resume" ]]; then
                 LACY_SHELL_PENDING_CMD="session_resume"

--- a/lib/zsh/execute.zsh
+++ b/lib/zsh/execute.zsh
@@ -91,8 +91,12 @@ lacy_shell_smart_accept_line() {
                 agent_input="${agent_input#"${agent_input%%[^[:space:]]*}"}"
             fi
 
-            # Add to history before clearing buffer
-            print -s -- "$input"
+            # Add to history before clearing buffer.
+            # Double backslashes before print -s: ZSH's print processes \X escape
+            # sequences even with -s, so "Google\ Chrome" becomes "Google Chrome".
+            # Doubling (\ → \\) makes print convert \\ → \, preserving the original.
+            local _hist_input="${input//\\/\\\\}"
+            print -s -- "$_hist_input"
             # Flush to HISTFILE immediately — needed for INC_APPEND_HISTORY / SHARE_HISTORY users,
             # since the subsequent empty-buffer accept-line doesn't trigger a file write.
             fc -AI 2>/dev/null


### PR DESCRIPTION
## Paperclip Issue
LAC-449

## Summary
- Commands starting with path prefixes (`/`, `./`, `../`, `~/`) were incorrectly routed to the AI agent when `command -v` couldn't verify the binary
- Paths with backslash-escaped spaces (e.g., `/Applications/Google\ Chrome.app/...`) were losing their backslashes in ZSH history

## Root Cause

**Bug 1 — Mis-routing:** `lacy_shell_classify_input` relied entirely on `command -v` to detect executables. When `command -v` failed (binary not installed, path with spaces edge cases), the function fell through to the "multiple words → agent" branch. For a command like `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222`, the arguments after the path are non-empty, so it classified as `agent`.

**Bug 2 — History backslash loss:** ZSH's `print` command (even with `-s`) processes `\X` escape sequences. An unrecognized `\ ` (backslash-space) is silently converted to just ` `. This caused history entries for agent-routed commands to drop backslashes.

## Fix

**`lib/core/detection.sh`:** Added early path-prefix check in `lacy_shell_classify_input` (auto mode only). If the input starts with `/`, `./`, `../`, or `~/`, it immediately routes to shell — no backslash-space extraction or `command -v` needed. This handles executables whose path includes spaces regardless of whether they're installed.

**`lib/zsh/execute.zsh`:** When adding agent-routed commands to ZSH history via `print -s`, double all backslashes first (`\ → \\`). ZSH's `print` then converts `\\` → `\`, preserving the original escaped path in history.

## Acceptance Criteria
- [ ] `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222` routes to shell (green indicator), not agent
- [ ] After the command runs, pressing Up retrieves it with backslashes intact
- [ ] `./script.sh --flag`, `../other/tool`, and `~/bin/tool` all route to shell
- [ ] Normal commands like `ls -la`, `git status`, natural language like `what files are here` still route correctly

## Testing Notes
Source `lacy.plugin.zsh` in a test shell and try the Chrome command. The indicator should turn green (shell) as you type the path. The `lacy_shell_test_detection` function can be used to verify the classification output.