### PR TITLE
feat: add Hermes agent as a supported AI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | opencode | `opencode run -c "query"` | `-c`         |
 | gemini   | `gemini --resume -p "query"` | `-p`         |
 | codex    | `codex exec resume --last "query"` | positional   |
+| hermes   | `hermes chat -q "query"` | `-q`         |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.

--- a/docs/ADDING-BACKENDS.md
+++ b/docs/ADDING-BACKENDS.md
@@ -1,0 +1,124 @@
+# Adding a New AI Backend to Lacy Shell
+
+This guide documents how to add a new AI CLI tool as a supported backend. The hermes integration (PR #40) serves as the reference implementation.
+
+## Prerequisites
+
+Before starting, verify the CLI tool supports:
+
+1. **Single-shot query mode** -- a flag that accepts a prompt string and exits after responding (e.g. `-p`, `-c`, `-q`)
+2. **Stdout output** -- response text goes to stdout, not a TUI
+3. **Session resume** (optional) -- a flag to continue a previous conversation
+
+## Integration Checklist
+
+### 1. Tool registry (`lib/core/mcp.sh`)
+
+Add two entries:
+
+```bash
+# lacy_tool_cmd() -- single-shot command
+your_tool) echo "your-tool query-flag" ;;
+
+# lacy_resume_cmd() -- session resume (or omit if unsupported)
+your_tool) echo "your-tool --resume-flag" ;;
+```
+
+The command string returned by `lacy_tool_cmd()` is split on whitespace and the user's query is appended as the final argument. So `"hermes chat -q"` becomes `hermes chat -q "user's query"`.
+
+Also add install hints to both the interactive prompt section and the non-interactive fallback section in `lacy_shell_query_agent()`.
+
+### 2. Tool list (`lib/core/constants.sh`)
+
+Append your tool to the `LACY_TOOL_LIST` array:
+
+```bash
+LACY_TOOL_LIST=(lash claude opencode gemini codex your_tool)
+```
+
+This controls auto-detection order and the `tool` command display.
+
+### 3. Session management (`lib/core/preheat.sh`)
+
+Add a session reuse block following the existing pattern:
+
+```bash
+LACY_YOURTOOL_SESSION_ID=""
+LACY_YOURTOOL_SESSION_ID_FILE="$LACY_SHELL_HOME/.yourtool_session_id_$$"
+
+lacy_preheat_yourtool_restore_session() { ... }
+lacy_preheat_yourtool_build_cmd() { ... }
+lacy_preheat_yourtool_capture_session() { ... }
+lacy_preheat_yourtool_extract_result() { ... }
+lacy_preheat_yourtool_reset_session() { ... }
+```
+
+Then wire it into:
+
+- `_lacy_get_current_tool()` -- add to the detection loop
+- `_lacy_save_last_session()` -- add case for session ID
+- `lacy_session_new()` -- call reset function
+- `lacy_session_resume()` -- add case to restore session
+- `lacy_preheat_cleanup()` -- delete session file
+
+If the tool uses `-p` for its prompt flag, `_lacy_session_build_cmd()` works as-is. For other flags (like hermes `chat -q`), add a conditional in that function.
+
+### 4. Help text (`lib/core/commands.sh`)
+
+Add your tool name to the options list in three places (search for `Options:`):
+
+```
+Options: lash, claude, opencode, gemini, codex, your_tool, custom, auto
+```
+
+### 5. Node installer (`packages/lacy/index.mjs`)
+
+Update these locations:
+
+- **TOOLS array** -- add selection entry with label and hint
+- **Detection loops** -- all `for (const tool of [...])` loops (3 locations)
+- **Install prompt** -- add a block after the lash install prompt if your tool has a simple install command
+
+For beta tools, use a label like `"your_tool (beta)"` to signal maturity.
+
+### 6. Docs
+
+- **`CLAUDE.md`** -- add row to the Supported AI CLI Tools table
+- **This file** -- reference your PR as an additional example if it introduces new patterns
+
+## Execution Paths
+
+Lacy has three execution paths in `lacy_shell_query_agent()`. Choose the right one:
+
+| Path | Used by | When to use |
+|------|---------|-------------|
+| **Server** (background `serve` + REST API) | lash, opencode | Tool has a `serve` command for persistent background process |
+| **JSON** (single-shot with JSON output parsing) | claude | Tool outputs structured JSON with session IDs |
+| **Generic** (streaming stdout) | codex, hermes, custom | Tool streams plain text to stdout |
+
+Most new tools use the **generic path** -- no special handling needed. The tool command runs, stdout streams to the terminal, and the spinner is killed on first output line.
+
+## Beta Integrations
+
+For tools that are new, experimental, or have unverified behavior:
+
+1. Add `(beta)` to the label in the TOOLS array: `label: "your_tool (beta)"`
+2. Note any known limitations in the PR description
+3. Open questions to verify with the tool installed:
+   - Does single-shot mode output cleanly to stdout (no TUI artifacts)?
+   - Are exit codes non-zero on errors?
+   - What is cold-start latency?
+   - Does session resume work as documented?
+
+## Reference: Hermes Integration (PR #40)
+
+The hermes backend added in PR #40 is a minimal example touching 6 files with ~90 lines changed:
+
+| File | Change |
+|------|--------|
+| `lib/core/constants.sh` | Added `hermes` to `LACY_TOOL_LIST` |
+| `lib/core/mcp.sh` | `hermes chat -q` in tool registry, `hermes --continue` for resume, install hints |
+| `lib/core/preheat.sh` | Session state, build cmd with `chat -q` flag, cleanup |
+| `lib/core/commands.sh` | Help text |
+| `packages/lacy/index.mjs` | Detection, selection with `(beta)` label, install prompt |
+| `CLAUDE.md` | Supported tools table |

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -168,7 +168,7 @@ lacy_shell_tool() {
         set)
             if [[ -z "$2" ]]; then
                 echo "Usage: tool set <name>"
-                echo "Options: lash, claude, opencode, gemini, codex, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi
@@ -197,7 +197,7 @@ lacy_shell_tool() {
             ;;
         *)
             echo "Usage: tool [set <name>]"
-            echo "Options: lash, claude, opencode, gemini, codex, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -190,7 +190,7 @@ LACY_SPINNER_FRAMES='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
 LACY_SPINNER_TEXT='Thinking'
 
 # === Tool List (canonical order for detection and display) ===
-LACY_TOOL_LIST=(lash claude opencode gemini codex)
+LACY_TOOL_LIST=(lash claude opencode gemini codex hermes)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -170,6 +170,7 @@ lacy_tool_cmd() {
         opencode) echo "opencode run -c" ;;
         gemini)   echo "gemini -p" ;;
         codex)    echo "codex exec resume --last" ;;
+        hermes)   echo "hermes chat -q" ;;
         *)        echo "" ;;
     esac
 }
@@ -201,6 +202,7 @@ lacy_resume_cmd() {
                 echo "gemini --resume $LACY_GEMINI_SESSION_ID"
             ;;
         codex)    echo "codex exec resume --last" ;;
+        hermes)   echo "hermes --continue" ;;
     esac
 }
 
@@ -418,6 +420,7 @@ EOF
                 echo "  opencode: brew install opencode"
                 echo "  gemini:   brew install gemini"
                 echo "  codex:    npm install -g @openai/codex"
+                echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
                 return 1
             fi
         else
@@ -428,6 +431,7 @@ EOF
             echo "  brew install opencode"
             echo "  brew install gemini"
             echo "  npm install -g @openai/codex"
+            echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
             return 1
         fi
     fi

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -277,11 +277,7 @@ _lacy_session_build_cmd() {
     if [[ "$tool" == "claude" ]]; then
         parts+=" --output-format json"
     fi
-    if [[ "$tool" == "hermes" ]]; then
-        parts+=" chat -q"
-    else
-        parts+=" -p"
-    fi
+    parts+=" -p"
     echo "$parts"
 }
 
@@ -360,33 +356,6 @@ lacy_preheat_gemini_reset_session() {
 }
 
 # ============================================================================
-# Hermes Session Reuse
-# ============================================================================
-
-LACY_HERMES_SESSION_ID=""
-LACY_HERMES_SESSION_ID_FILE="$LACY_SHELL_HOME/.hermes_session_id_$$"
-
-lacy_preheat_hermes_restore_session() {
-    _lacy_session_restore "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
-}
-
-lacy_preheat_hermes_build_cmd() {
-    _lacy_session_build_cmd "hermes" "$LACY_HERMES_SESSION_ID" "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
-}
-
-lacy_preheat_hermes_capture_session() {
-    _lacy_session_capture "$1" "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID" "session_id"
-}
-
-lacy_preheat_hermes_extract_result() {
-    _lacy_json_get "$1" "response"
-}
-
-lacy_preheat_hermes_reset_session() {
-    _lacy_session_reset "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
-}
-
-# ============================================================================
 # Session Commands (new / resume)
 # ============================================================================
 
@@ -413,7 +382,6 @@ _lacy_save_last_session() {
         lash|opencode) session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
         claude)        session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
         gemini)        session_id="$LACY_GEMINI_SESSION_ID" ;;
-        hermes)        session_id="$LACY_HERMES_SESSION_ID" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -429,7 +397,6 @@ lacy_session_new() {
     # Reset all per-session state
     lacy_preheat_claude_reset_session
     lacy_preheat_gemini_reset_session
-    lacy_preheat_hermes_reset_session
     LACY_PREHEAT_SERVER_SESSION_ID=""
     rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
 
@@ -491,10 +458,6 @@ lacy_session_resume() {
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
             ;;
-        hermes)
-            LACY_HERMES_SESSION_ID="$saved_id"
-            echo "$saved_id" > "$LACY_HERMES_SESSION_ID_FILE"
-            ;;
     esac
 
     echo ""
@@ -526,6 +489,5 @@ lacy_preheat_init() {
 lacy_preheat_cleanup() {
     lacy_preheat_server_stop
     rm -f "$LACY_PREHEAT_SESSION_FILE" \
-          "$LACY_GEMINI_SESSION_ID_FILE" \
-          "$LACY_HERMES_SESSION_ID_FILE"
+          "$LACY_GEMINI_SESSION_ID_FILE"
 }

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -277,7 +277,11 @@ _lacy_session_build_cmd() {
     if [[ "$tool" == "claude" ]]; then
         parts+=" --output-format json"
     fi
-    parts+=" -p"
+    if [[ "$tool" == "hermes" ]]; then
+        parts+=" chat -q"
+    else
+        parts+=" -p"
+    fi
     echo "$parts"
 }
 
@@ -356,6 +360,33 @@ lacy_preheat_gemini_reset_session() {
 }
 
 # ============================================================================
+# Hermes Session Reuse
+# ============================================================================
+
+LACY_HERMES_SESSION_ID=""
+LACY_HERMES_SESSION_ID_FILE="$LACY_SHELL_HOME/.hermes_session_id_$$"
+
+lacy_preheat_hermes_restore_session() {
+    _lacy_session_restore "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
+}
+
+lacy_preheat_hermes_build_cmd() {
+    _lacy_session_build_cmd "hermes" "$LACY_HERMES_SESSION_ID" "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
+}
+
+lacy_preheat_hermes_capture_session() {
+    _lacy_session_capture "$1" "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID" "session_id"
+}
+
+lacy_preheat_hermes_extract_result() {
+    _lacy_json_get "$1" "response"
+}
+
+lacy_preheat_hermes_reset_session() {
+    _lacy_session_reset "$LACY_HERMES_SESSION_ID_FILE" "LACY_HERMES_SESSION_ID"
+}
+
+# ============================================================================
 # Session Commands (new / resume)
 # ============================================================================
 
@@ -366,7 +397,7 @@ _lacy_get_current_tool() {
         return
     fi
     local t
-    for t in lash opencode claude gemini codex; do
+    for t in lash opencode claude gemini codex hermes; do
         command -v "$t" >/dev/null 2>&1 && { echo "$t"; return; }
     done
 }
@@ -382,6 +413,7 @@ _lacy_save_last_session() {
         lash|opencode) session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
         claude)        session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
         gemini)        session_id="$LACY_GEMINI_SESSION_ID" ;;
+        hermes)        session_id="$LACY_HERMES_SESSION_ID" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -397,6 +429,7 @@ lacy_session_new() {
     # Reset all per-session state
     lacy_preheat_claude_reset_session
     lacy_preheat_gemini_reset_session
+    lacy_preheat_hermes_reset_session
     LACY_PREHEAT_SERVER_SESSION_ID=""
     rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
 
@@ -458,6 +491,10 @@ lacy_session_resume() {
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
             ;;
+        hermes)
+            LACY_HERMES_SESSION_ID="$saved_id"
+            echo "$saved_id" > "$LACY_HERMES_SESSION_ID_FILE"
+            ;;
     esac
 
     echo ""
@@ -489,5 +526,6 @@ lacy_preheat_init() {
 lacy_preheat_cleanup() {
     lacy_preheat_server_stop
     rm -f "$LACY_PREHEAT_SESSION_FILE" \
-          "$LACY_GEMINI_SESSION_ID_FILE"
+          "$LACY_GEMINI_SESSION_ID_FILE" \
+          "$LACY_HERMES_SESSION_ID_FILE"
 }

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -566,26 +566,23 @@ async function install() {
     }
 
     if (installHermes) {
-      const hermesSpinner = p.spinner();
-      hermesSpinner.start("Installing hermes");
+      p.log.info("Running hermes installer...");
 
       try {
         if (commandExists("curl")) {
           execSync(
             "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
-            { stdio: "pipe" },
+            { stdio: "inherit" },
           );
-          hermesSpinner.stop("hermes installed");
+          p.log.success("hermes installed");
         } else {
-          hermesSpinner.stop("Could not install hermes");
           p.log.warn(
-            "Please install curl, then run: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+            "curl not found. Install manually: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
           );
         }
       } catch (e) {
-        hermesSpinner.stop("hermes installation failed");
         p.log.warn(
-          "You can install it manually later: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+          "Installation failed. You can install manually: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
         );
       }
     }

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -164,6 +164,7 @@ const TOOLS = [
   { value: "opencode", label: "opencode", hint: "OpenCode CLI" },
   { value: "gemini", label: "gemini", hint: "Google Gemini CLI" },
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
+  { value: "hermes", label: "hermes", hint: "Hermes Agent — Nous Research" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -411,7 +412,7 @@ async function install() {
 
   // Detect installed tools
   let detected = [];
-  for (const tool of ["lash", "claude", "opencode", "gemini", "codex"]) {
+  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
     if (commandExists(tool)) {
       detected.push(tool);
     }
@@ -776,7 +777,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
     const active = readConfigValue("active");
     const mode = readConfigValue("default");
     const detected = [];
-    for (const tool of ["lash", "claude", "opencode", "gemini", "codex"]) {
+    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
       if (commandExists(tool)) detected.push(tool);
     }
 
@@ -937,7 +938,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           `  Mode:       ${pc.cyan(modeDisplay)}`,
           ``,
           `  ${pc.bold("AI CLI tools:")}`,
-          ...["lash", "claude", "opencode", "gemini", "codex"].map((t) =>
+          ...["lash", "claude", "opencode", "gemini", "codex", "hermes"].map((t) =>
             commandExists(t)
               ? `    ${pc.green("✓")} ${t}`
               : `    ${pc.dim("○")} ${pc.dim(t)}`,

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -553,6 +553,44 @@ async function install() {
     }
   }
 
+  // Offer to install hermes if selected but not installed
+  if (selectedTool === "hermes" && !commandExists("hermes")) {
+    const installHermes = await p.confirm({
+      message: "hermes is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installHermes)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installHermes) {
+      const hermesSpinner = p.spinner();
+      hermesSpinner.start("Installing hermes");
+
+      try {
+        if (commandExists("curl")) {
+          execSync(
+            "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+            { stdio: "pipe" },
+          );
+          hermesSpinner.stop("hermes installed");
+        } else {
+          hermesSpinner.stop("Could not install hermes");
+          p.log.warn(
+            "Please install curl, then run: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+          );
+        }
+      } catch (e) {
+        hermesSpinner.stop("hermes installation failed");
+        p.log.warn(
+          "You can install it manually later: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+        );
+      }
+    }
+  }
+
   // Clone/update repository
   const installSpinner = p.spinner();
   installSpinner.start("Installing Lacy");

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -164,7 +164,7 @@ const TOOLS = [
   { value: "opencode", label: "opencode", hint: "OpenCode CLI" },
   { value: "gemini", label: "gemini", hint: "Google Gemini CLI" },
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
-  { value: "hermes", label: "hermes", hint: "Hermes Agent — Nous Research" },
+  { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -296,7 +296,15 @@ assert_false "in_list not found" _lacy_in_list "d" "a" "b" "c"
 source "$REPO_DIR/lib/core/mcp.sh"
 assert_eq "tool cmd lash" "lash run -c" "$(lacy_tool_cmd 'lash')"
 assert_eq "tool cmd claude" "claude -p" "$(lacy_tool_cmd 'claude')"
+assert_eq "tool cmd hermes" "hermes chat -q" "$(lacy_tool_cmd 'hermes')"
 assert_eq "tool cmd unknown" "" "$(lacy_tool_cmd 'unknown')"
+
+# Hermes in LACY_TOOL_LIST
+assert_true "hermes in tool list" _lacy_in_list "hermes" "${LACY_TOOL_LIST[@]}"
+
+# Hermes resume command
+source "$REPO_DIR/lib/core/preheat.sh"
+assert_eq "hermes resume cmd" "hermes --continue" "$(lacy_resume_cmd 'hermes')"
 
 # ============================================================================
 # Telemetry JSON Escaping Tests


### PR DESCRIPTION
## Summary

- Adds [Hermes Agent](https://hermes-agent.nousresearch.com/) (Nous Research) as a supported AI backend
- Single-shot queries via `hermes chat -q`, session resume via `hermes --continue`
- Uses generic execution path (like codex) — no custom handling needed
- Node installer prompts to install hermes via official curl script when selected but not installed

## Changes

- `lib/core/constants.sh` — added `hermes` to `LACY_TOOL_LIST`
- `lib/core/mcp.sh` — tool registry (`hermes chat -q`), resume cmd (`hermes --continue`), install hints
- `lib/core/preheat.sh` — session management scaffolding, `_lacy_session_build_cmd` handles hermes `chat -q` flag
- `lib/core/commands.sh` — updated help text with hermes option
- `packages/lacy/index.mjs` — detection, selection, and install prompt for hermes
- `CLAUDE.md` — supported tools table

## Test plan

- [ ] Verify `tool set hermes` works and `tool` shows hermes in available list
- [ ] Verify `hermes chat -q "hello"` executes correctly through generic path (requires hermes installed)
- [ ] Verify Node installer (`npx lacy`) shows hermes in tool selection
- [ ] Verify install prompt appears when hermes is selected but not installed
- [ ] Verify `/new` and `/resume` session commands handle hermes state