### PR TITLE
feat: add Goose CLI backend (LAC-1145)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | codex    | `codex exec resume --last "query"` | positional   |
 | hermes   | `hermes chat -q "query"` | `-q`         |
 | copilot  | `copilot -p "query"`   | `-p`         |
+| goose    | `goose run -t "query"` | `-t`         |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -168,7 +168,7 @@ lacy_shell_tool() {
         set)
             if [[ -z "$2" ]]; then
                 echo "Usage: tool set <name>"
-                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi
@@ -197,7 +197,7 @@ lacy_shell_tool() {
             ;;
         *)
             echo "Usage: tool [set <name>]"
-            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -190,7 +190,7 @@ LACY_SPINNER_FRAMES='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
 LACY_SPINNER_TEXT='Thinking'
 
 # === Tool List (canonical order for detection and display) ===
-LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot)
+LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot goose)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -172,6 +172,7 @@ lacy_tool_cmd() {
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes chat -q" ;;
         copilot)  echo "copilot -p" ;;
+        goose)    echo "goose run -t" ;;
         *)        echo "" ;;
     esac
 }
@@ -205,6 +206,7 @@ lacy_resume_cmd() {
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes --continue" ;;
         copilot)  echo "copilot --resume" ;;
+        goose)    echo "goose session resume" ;;
     esac
 }
 
@@ -424,6 +426,7 @@ EOF
                 echo "  codex:    npm install -g @openai/codex"
                 echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
                 echo "  copilot:  gh extension install github/gh-copilot"
+                echo "  goose:    brew install goose"
                 return 1
             fi
         else
@@ -436,6 +439,7 @@ EOF
             echo "  npm install -g @openai/codex"
             echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
             echo "  gh extension install github/gh-copilot  (copilot)"
+            echo "  brew install goose"
             return 1
         fi
     fi

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -366,7 +366,7 @@ _lacy_get_current_tool() {
         return
     fi
     local t
-    for t in lash opencode claude gemini codex hermes copilot; do
+    for t in lash opencode claude gemini codex hermes copilot goose; do
         command -v "$t" >/dev/null 2>&1 && { echo "$t"; return; }
     done
 }

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -366,7 +366,7 @@ _lacy_get_current_tool() {
         return
     fi
     local t
-    for t in lash opencode claude gemini codex hermes copilot goose; do
+    for t in "${LACY_TOOL_LIST[@]}"; do
         command -v "$t" >/dev/null 2>&1 && { echo "$t"; return; }
     done
 }
@@ -382,7 +382,7 @@ _lacy_save_last_session() {
         lash|opencode)   session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
         claude)          session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
         gemini)          session_id="$LACY_GEMINI_SESSION_ID" ;;
-        codex|copilot)   session_id="default" ;;
+        codex|hermes|copilot|goose) session_id="default" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -459,7 +459,7 @@ lacy_session_resume() {
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
             ;;
-        codex|copilot)
+        codex|hermes|copilot|goose)
             ;;
     esac
 

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -166,7 +166,7 @@ const TOOLS = [
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
   { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
   { value: "copilot", label: "copilot (beta)", hint: "GitHub Copilot CLI" },
-  { value: "goose", label: "goose", hint: "Block's Goose AI agent" },
+  { value: "goose", label: "goose (beta)", hint: "Block's Goose AI agent" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -166,6 +166,7 @@ const TOOLS = [
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
   { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
   { value: "copilot", label: "copilot (beta)", hint: "GitHub Copilot CLI" },
+  { value: "goose", label: "goose", hint: "Block's Goose AI agent" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -413,7 +414,7 @@ async function install() {
 
   // Detect installed tools
   let detected = [];
-  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot"]) {
+  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"]) {
     if (commandExists(tool)) {
       detected.push(tool);
     }
@@ -621,6 +622,40 @@ async function install() {
     }
   }
 
+  // Offer to install goose if selected but not installed
+  if (selectedTool === "goose" && !commandExists("goose")) {
+    const installGoose = await p.confirm({
+      message: "goose is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installGoose)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installGoose) {
+      const gooseSpinner = p.spinner();
+      gooseSpinner.start("Installing goose");
+
+      try {
+        if (commandExists("brew")) {
+          execSync("brew install goose", { stdio: "pipe" });
+          gooseSpinner.stop("goose installed");
+        } else {
+          gooseSpinner.stop("Could not install goose");
+          p.log.warn(
+            "Please install homebrew, then run: brew install goose",
+          );
+        }
+      } catch (e) {
+        gooseSpinner.stop("goose installation failed");
+        p.log.warn(
+          "You can install it manually later: brew install goose",
+        );
+      }
+    }
+  }
 
   // Clone/update repository
   const installSpinner = p.spinner();
@@ -846,7 +881,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
     const active = readConfigValue("active");
     const mode = readConfigValue("default");
     const detected = [];
-    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot"]) {
+    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"]) {
       if (commandExists(tool)) detected.push(tool);
     }
 
@@ -1007,7 +1042,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           `  Mode:       ${pc.cyan(modeDisplay)}`,
           ``,
           `  ${pc.bold("AI CLI tools:")}`,
-          ...["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot"].map((t) =>
+          ...["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"].map((t) =>
             commandExists(t)
               ? `    ${pc.green("✓")} ${t}`
               : `    ${pc.dim("○")} ${pc.dim(t)}`,

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -414,7 +414,7 @@ async function install() {
 
   // Detect installed tools
   let detected = [];
-  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"]) {
+  for (const tool of TOOLS.filter((t) => !["custom", "auto", "none"].includes(t.value)).map((t) => t.value)) {
     if (commandExists(tool)) {
       detected.push(tool);
     }
@@ -616,7 +616,7 @@ async function install() {
         }
       } catch (e) {
         p.log.warn(
-          "Installation failed. You can install manually: gh extension install github/gh-copilot",
+          `Installation failed: ${e.message}. You can install manually: gh extension install github/gh-copilot`,
         );
       }
     }
@@ -649,7 +649,7 @@ async function install() {
           );
         }
       } catch (e) {
-        gooseSpinner.stop("goose installation failed");
+        gooseSpinner.stop(`goose installation failed: ${e.message}`);
         p.log.warn(
           "You can install it manually later: brew install goose",
         );
@@ -881,7 +881,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
     const active = readConfigValue("active");
     const mode = readConfigValue("default");
     const detected = [];
-    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"]) {
+    for (const tool of TOOLS.filter((t) => !["custom", "auto", "none"].includes(t.value)).map((t) => t.value)) {
       if (commandExists(tool)) detected.push(tool);
     }
 
@@ -1042,7 +1042,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           `  Mode:       ${pc.cyan(modeDisplay)}`,
           ``,
           `  ${pc.bold("AI CLI tools:")}`,
-          ...["lash", "claude", "opencode", "gemini", "codex", "hermes", "copilot", "goose"].map((t) =>
+          ...TOOLS.filter((t) => !["custom", "auto", "none"].includes(t.value)).map(({ value: t }) =>
             commandExists(t)
               ? `    ${pc.green("✓")} ${t}`
               : `    ${pc.dim("○")} ${pc.dim(t)}`,


### PR DESCRIPTION
## Summary

- Adds Block's Goose CLI as a supported AI tool backend for Lacy Shell
- Follows the same integration pattern used for copilot (LAC-1087)
- Generic execution path — no server mode needed (fast ~100ms startup)

## Changes

| File | Change |
|------|--------|
| `lib/core/constants.sh` | Added `goose` to `LACY_TOOL_LIST` |
| `lib/core/mcp.sh` | Added `goose run -t` to `lacy_tool_cmd()`, `goose session resume` to `lacy_resume_cmd()`, goose in install hint lists |
| `lib/core/preheat.sh` | Added `goose` to `_lacy_get_current_tool()` fallback scan |
| `lib/core/commands.sh` | Added `goose` to tool help text and options |
| `packages/lacy/index.mjs` | Added goose to TOOLS list, detection loops, status page, install prompt |
| `CLAUDE.md` | Added goose to supported tools table |

## Paperclip Issue

https://app.paperclip.ai/LAC/issues/LAC-1145

## Acceptance Criteria

- [x] `tool set goose` switches active tool
- [x] `tool` shows goose as an available option (installed/not installed)
- [x] Query routes via `goose run -t`
- [x] `/resume` shows `goose session resume` hint
- [x] Node installer detects goose if installed
- [x] Node installer offers goose in tool selection list
- [x] Node installer offers `brew install goose` if goose selected but not installed
- [x] `lacy doctor` detects goose (via `LACY_TOOL_LIST`)

## Testing Notes

Uses generic execution path (same as codex/copilot) — no special session state handling needed. The `goose run -t "query"` single-shot command passes the query as the `-t` flag argument.