### PR TITLE
feat: add Aider as a supported AI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | copilot  | `copilot -p "query"`   | `-p`         |
 | goose    | `goose run -t "query"` | `-t`         |
 | amp      | `amp -x "query"`       | `-x`         |
+| aider    | `aider --no-auto-commits --message "query"` | `--message`  |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.
@@ -268,7 +269,7 @@ LACY_NO_NODE=1 bin/lacy setup
 - `mode [shell|agent|auto]` - Switch modes
 - `mode` - Show current mode and color legend
 - `tool` - Show active AI tool and available tools
-- `tool set <name>` - Set AI tool (lash, claude, opencode, gemini, codex, custom, auto) — persists to config.yaml
+- `tool set <name>` - Set AI tool (lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, aider, custom, auto) — persists to config.yaml
 - `tool set custom "cmd"` - Set a custom command as the AI tool
 - `/new` / `/reset` / `/clear` - Start a new conversation session
 - `/resume` - Resume the last saved session
@@ -301,7 +302,7 @@ Config file: `~/.lacy/config.yaml`
 
 ```yaml
 agent_tools:
-  active: claude # or lash, opencode, gemini, codex, custom, empty for auto
+  active: claude # or lash, opencode, gemini, codex, hermes, copilot, goose, amp, aider, custom, empty for auto
   # custom_command: "your-command -flags"  # used when active: custom
 
 api_keys:

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -172,7 +172,7 @@ lacy_shell_tool() {
         set)
             if [[ -z "$2" ]]; then
                 echo "Usage: tool set <name>"
-                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, aider, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi
@@ -201,7 +201,7 @@ lacy_shell_tool() {
             ;;
         *)
             echo "Usage: tool [set <name>]"
-            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, aider, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -192,7 +192,7 @@ LACY_SPINNER_FRAMES='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
 LACY_SPINNER_TEXT='Thinking'
 
 # === Tool List (canonical order for detection and display) ===
-LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot goose amp)
+LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot goose amp aider)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -174,6 +174,7 @@ lacy_tool_cmd() {
         copilot)  echo "copilot -p" ;;
         goose)    echo "goose run -t" ;;
         amp)      echo "amp -x" ;;
+        aider)    echo "aider --no-auto-commits --message" ;;
         *)        echo "" ;;
     esac
 }
@@ -456,6 +457,7 @@ EOF
                 echo "  copilot:  gh extension install github/gh-copilot"
                 echo "  goose:    brew install goose"
                 echo "  amp:      npm install -g @sourcegraph/amp"
+                echo "  aider:    pipx install aider-chat"
                 return 1
             fi
         else
@@ -470,6 +472,7 @@ EOF
             echo "  gh extension install github/gh-copilot  (copilot)"
             echo "  brew install goose"
             echo "  npm install -g @sourcegraph/amp"
+            echo "  pipx install aider-chat  (aider)"
             return 1
         fi
     fi

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -168,6 +168,7 @@ const TOOLS = [
   { value: "copilot", label: "copilot (beta)", hint: "GitHub Copilot CLI" },
   { value: "goose", label: "goose (beta)", hint: "Block's Goose AI agent" },
   { value: "amp", label: "amp", hint: "Sourcegraph Amp CLI" },
+  { value: "aider", label: "aider", hint: "Aider AI pair programming — pipx install aider-chat" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -688,6 +689,44 @@ async function install() {
         ampSpinner.stop("amp installation failed");
         p.log.warn(
           "You can install it manually later: npm install -g @sourcegraph/amp",
+        );
+      }
+    }
+  }
+
+  // Offer to install aider if selected but not installed
+  if (selectedTool === "aider" && !commandExists("aider")) {
+    const installAider = await p.confirm({
+      message: "aider is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installAider)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installAider) {
+      const aiderSpinner = p.spinner();
+      aiderSpinner.start("Installing aider");
+
+      try {
+        if (commandExists("pipx")) {
+          execSync("pipx install aider-chat", { stdio: "pipe" });
+          aiderSpinner.stop("aider installed");
+        } else if (commandExists("pip3")) {
+          execSync("pip3 install --user aider-chat", { stdio: "pipe" });
+          aiderSpinner.stop("aider installed");
+        } else {
+          aiderSpinner.stop("Could not install aider");
+          p.log.warn(
+            "Please install pipx, then run: pipx install aider-chat",
+          );
+        }
+      } catch (e) {
+        aiderSpinner.stop("aider installation failed");
+        p.log.warn(
+          "You can install it manually later: pipx install aider-chat",
         );
       }
     }


### PR DESCRIPTION
## Summary

- Adds `aider` to `LACY_TOOL_LIST` in `lib/core/constants.sh` for detection and display
- Registers `aider --no-auto-commits --message` in `lacy_tool_cmd()` — the `--no-auto-commits` flag is critical to prevent aider from auto-committing git changes when invoked from Lacy
- Adds aider to auto-detection loop in `_lacy_get_current_tool()` (preheat.sh)
- Adds aider to all help text / options lists in `commands.sh`
- Adds aider to Node installer: TOOLS list, detection loops, install prompt (`pipx install aider-chat`), and status page tool check
- Updates `CLAUDE.md` supported tools table with aider's command signature
- No session state or preheat needed — aider is stateless by design

## Paperclip Issue

https://paperclip.buildandserve.com/LAC/issues/LAC-1146

## Testing Notes

- `tool set aider` — switches active tool
- `tool` — shows aider as active with command `aider --no-auto-commits --message`
- Queries route via generic path (same as codex/custom) — no special preheat handling
- `/new` is a no-op (stateless)
- `/resume` returns "No conversation history found" (no resume support)
- Node installer detects aider if installed and offers `pipx install aider-chat` if not
- `lacy doctor` detects aider binary via the standard `command -v` check