### PR TITLE
feat: add Sourcegraph Amp CLI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | codex    | `codex exec resume --last "query"` | positional   |
 | hermes   | `hermes chat -q "query"` | `-q`         |
 | copilot  | `copilot -p "query"`   | `-p`         |
+| amp      | `amp -x "query"`       | `-x`         |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | gemini   | `gemini --resume -p "query"` | `-p`         |
 | codex    | `codex exec resume --last "query"` | positional   |
 | hermes   | `hermes chat -q "query"` | `-q`         |
+| copilot  | `copilot -p "query"`   | `-p`         |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.

--- a/bin/lacy
+++ b/bin/lacy
@@ -348,7 +348,7 @@ cmd_status() {
 
     # AI tools
     printf "\n${BOLD}AI CLI Tools${NC}\n"
-    for t in lash claude opencode gemini codex; do
+    for t in lash claude opencode gemini codex copilot amp; do
         if command_exists "$t"; then
             success "$t"
         else
@@ -425,7 +425,7 @@ cmd_doctor() {
 
     # Check AI tool
     local found_tool=0
-    for t in lash claude opencode gemini codex; do
+    for t in lash claude opencode gemini codex copilot amp; do
         if command_exists "$t"; then
             found_tool=1
             break
@@ -552,8 +552,8 @@ setup_tool() {
     printf "\n${BOLD}Select AI tool${NC}\n\n"
 
     local i=1
-    local tools=("lash" "claude" "opencode" "gemini" "codex" "custom" "auto")
-    local hints=("AI coding agent (recommended)" "Claude Code CLI" "OpenCode CLI" "Google Gemini CLI" "OpenAI Codex CLI" "enter your own command" "use first available")
+    local tools=("lash" "claude" "opencode" "gemini" "codex" "copilot" "amp" "custom" "auto")
+    local hints=("AI coding agent (recommended)" "Claude Code CLI" "OpenCode CLI" "Google Gemini CLI" "OpenAI Codex CLI" "GitHub Copilot CLI" "Sourcegraph Amp CLI" "enter your own command" "use first available")
 
     for t in "${tools[@]}"; do
         local hint="${hints[$((i-1))]}"

--- a/install.sh
+++ b/install.sh
@@ -275,7 +275,7 @@ detect_tools() {
     printf "${BLUE}Detecting AI CLI tools...${NC}\n"
     local found=0
 
-    for tool in lash claude opencode gemini codex; do
+    for tool in lash claude opencode gemini codex copilot amp; do
         if command -v "$tool" >/dev/null 2>&1; then
             printf "  ${GREEN}✓${NC} $tool\n"
             found=1
@@ -311,13 +311,15 @@ select_tool() {
     printf "  3) opencode   ${DIM}- OpenCode CLI${NC}\n"
     printf "  4) gemini     ${DIM}- Google Gemini CLI${NC}\n"
     printf "  5) codex      ${DIM}- OpenAI Codex CLI${NC}\n"
-    printf "  6) Auto-detect ${DIM}(use first available)${NC}\n"
-    printf "  7) None       ${DIM}- I'll install one later${NC}\n"
-    printf "  8) Custom     ${DIM}- enter your own command${NC}\n"
+    printf "  6) copilot    ${DIM}- GitHub Copilot CLI${NC}\n"
+    printf "  7) amp        ${DIM}- Sourcegraph Amp CLI${NC}\n"
+    printf "  8) Auto-detect ${DIM}(use first available)${NC}\n"
+    printf "  9) None       ${DIM}- I'll install one later${NC}\n"
+    printf " 10) Custom     ${DIM}- enter your own command${NC}\n"
     printf "\n"
 
     local choice
-    read -p "Select [1-8, default=6]: " choice < /dev/tty 2>/dev/null || choice="6"
+    read -p "Select [1-10, default=8]: " choice < /dev/tty 2>/dev/null || choice="8"
 
     case "$choice" in
         1) SELECTED_TOOL="lash" ;;
@@ -325,9 +327,11 @@ select_tool() {
         3) SELECTED_TOOL="opencode" ;;
         4) SELECTED_TOOL="gemini" ;;
         5) SELECTED_TOOL="codex" ;;
-        6|"") SELECTED_TOOL="" ;;
-        7) SELECTED_TOOL="none" ;;
-        8)
+        6) SELECTED_TOOL="copilot" ;;
+        7) SELECTED_TOOL="amp" ;;
+        8|"") SELECTED_TOOL="" ;;
+        9) SELECTED_TOOL="none" ;;
+        10)
             SELECTED_TOOL="custom"
             printf "\n"
             read -p "Enter command (e.g. claude --dangerously-skip-permissions -p): " CUSTOM_COMMAND < /dev/tty 2>/dev/null || CUSTOM_COMMAND=""
@@ -360,6 +364,8 @@ select_tool() {
                     opencode) printf "  brew install opencode\n" ;;
                     gemini) printf "  brew install gemini\n" ;;
                     codex) printf "  npm install -g @openai/codex\n" ;;
+                    copilot) printf "  gh extension install github/gh-copilot\n" ;;
+                    amp) printf "  npm install -g @sourcegraph/amp\n" ;;
                 esac
             fi
         fi
@@ -373,7 +379,7 @@ select_tool() {
         # Auto-detect: check if any tool is available
         printf "\n"
         local first_tool_found=""
-        for t in lash claude opencode gemini codex; do
+        for t in lash claude opencode gemini codex copilot amp; do
             if command -v "$t" >/dev/null 2>&1; then
                 first_tool_found="$t"
                 break

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -170,6 +170,7 @@ lacy_shell_tool() {
                 echo "Usage: tool set <name>"
                 echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
                 echo "Options: lash, claude, opencode, gemini, codex, copilot, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, copilot, amp, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -169,6 +169,7 @@ lacy_shell_tool() {
             if [[ -z "$2" ]]; then
                 echo "Usage: tool set <name>"
                 echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, copilot, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi
@@ -198,6 +199,7 @@ lacy_shell_tool() {
         *)
             echo "Usage: tool [set <name>]"
             echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, copilot, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -199,8 +199,7 @@ lacy_shell_tool() {
             ;;
         *)
             echo "Usage: tool [set <name>]"
-            echo "Options: lash, claude, opencode, gemini, codex, hermes, custom, auto"
-            echo "Options: lash, claude, opencode, gemini, codex, copilot, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, amp, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -274,7 +274,7 @@ appearance:
 # AI CLI tool selection
 # Lacy auto-detects installed tools, or you can set one explicitly
 agent_tools:
-  # Options: lash, claude, opencode, gemini, codex, custom, or empty for auto-detect
+  # Options: lash, claude, opencode, gemini, codex, copilot, amp, custom, or empty for auto-detect
   active:
   # Custom command (used when active: custom)
   # custom_command: "your-command -flags"

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -191,6 +191,7 @@ LACY_SPINNER_TEXT='Thinking'
 
 # === Tool List (canonical order for detection and display) ===
 LACY_TOOL_LIST=(lash claude opencode gemini codex hermes)
+LACY_TOOL_LIST=(lash claude opencode gemini codex copilot)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -192,6 +192,7 @@ LACY_SPINNER_TEXT='Thinking'
 # === Tool List (canonical order for detection and display) ===
 LACY_TOOL_LIST=(lash claude opencode gemini codex hermes)
 LACY_TOOL_LIST=(lash claude opencode gemini codex copilot)
+LACY_TOOL_LIST=(lash claude opencode gemini codex copilot amp)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -423,7 +423,7 @@ EOF
                 echo "  gemini:   brew install gemini"
                 echo "  codex:    npm install -g @openai/codex"
                 echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
-                echo "  copilot:  npm install -g @github/copilot"
+                echo "  copilot:  gh extension install github/gh-copilot"
                 return 1
             fi
         else
@@ -435,7 +435,7 @@ EOF
             echo "  brew install gemini"
             echo "  npm install -g @openai/codex"
             echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
-            echo "  npm install -g @github/copilot"
+            echo "  gh extension install github/gh-copilot"
             return 1
         fi
     fi

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -172,6 +172,7 @@ lacy_tool_cmd() {
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes chat -q" ;;
         copilot)  echo "copilot -p" ;;
+        amp)      echo "amp -x" ;;
         *)        echo "" ;;
     esac
 }
@@ -205,6 +206,7 @@ lacy_resume_cmd() {
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes --continue" ;;
         copilot)  echo "copilot --resume" ;;
+        amp)      echo "amp --continue" ;;
     esac
 }
 
@@ -424,6 +426,7 @@ EOF
                 echo "  codex:    npm install -g @openai/codex"
                 echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
                 echo "  copilot:  gh extension install github/gh-copilot"
+                echo "  amp:      npm install -g @sourcegraph/amp"
                 return 1
             fi
         else
@@ -436,6 +439,7 @@ EOF
             echo "  npm install -g @openai/codex"
             echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
             echo "  gh extension install github/gh-copilot"
+            echo "  npm install -g @sourcegraph/amp"
             return 1
         fi
     fi

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -171,6 +171,7 @@ lacy_tool_cmd() {
         gemini)   echo "gemini -p" ;;
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes chat -q" ;;
+        copilot)  echo "copilot -p" ;;
         *)        echo "" ;;
     esac
 }
@@ -203,6 +204,7 @@ lacy_resume_cmd() {
             ;;
         codex)    echo "codex exec resume --last" ;;
         hermes)   echo "hermes --continue" ;;
+        copilot)  echo "copilot --resume" ;;
     esac
 }
 
@@ -421,6 +423,7 @@ EOF
                 echo "  gemini:   brew install gemini"
                 echo "  codex:    npm install -g @openai/codex"
                 echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+                echo "  copilot:  npm install -g @github/copilot"
                 return 1
             fi
         else
@@ -432,6 +435,7 @@ EOF
             echo "  brew install gemini"
             echo "  npm install -g @openai/codex"
             echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
+            echo "  npm install -g @github/copilot"
             return 1
         fi
     fi

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -367,6 +367,7 @@ _lacy_get_current_tool() {
     fi
     local t
     for t in lash opencode claude gemini codex hermes; do
+    for t in lash opencode claude gemini codex copilot; do
         command -v "$t" >/dev/null 2>&1 && { echo "$t"; return; }
     done
 }

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -368,6 +368,7 @@ _lacy_get_current_tool() {
     local t
     for t in lash opencode claude gemini codex hermes; do
     for t in lash opencode claude gemini codex copilot; do
+    for t in lash opencode claude gemini codex copilot amp; do
         command -v "$t" >/dev/null 2>&1 && { echo "$t"; return; }
     done
 }
@@ -383,7 +384,7 @@ _lacy_save_last_session() {
         lash|opencode)   session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
         claude)          session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
         gemini)          session_id="$LACY_GEMINI_SESSION_ID" ;;
-        codex|copilot)   session_id="default" ;;
+        codex|copilot|amp) session_id="default" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -460,7 +461,7 @@ lacy_session_resume() {
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
             ;;
-        codex|copilot)
+        codex|copilot|amp)
             ;;
     esac
 

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -380,9 +380,10 @@ _lacy_save_last_session() {
 
     local session_id=""
     case "$tool" in
-        lash|opencode) session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
-        claude)        session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
-        gemini)        session_id="$LACY_GEMINI_SESSION_ID" ;;
+        lash|opencode)   session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
+        claude)          session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
+        gemini)          session_id="$LACY_GEMINI_SESSION_ID" ;;
+        codex|copilot)   session_id="default" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -458,6 +459,8 @@ lacy_session_resume() {
         gemini)
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
+            ;;
+        codex|copilot)
             ;;
     esac
 

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -165,6 +165,7 @@ const TOOLS = [
   { value: "gemini", label: "gemini", hint: "Google Gemini CLI" },
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
   { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
+  { value: "copilot", label: "copilot", hint: "GitHub Copilot CLI" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -413,6 +414,7 @@ async function install() {
   // Detect installed tools
   let detected = [];
   for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
+  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot"]) {
     if (commandExists(tool)) {
       detected.push(tool);
     }
@@ -583,6 +585,41 @@ async function install() {
       } catch (e) {
         p.log.warn(
           "Installation failed. You can install manually: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
+        );
+      }
+    }
+  }
+
+  // Offer to install copilot if selected but not installed
+  if (selectedTool === "copilot" && !commandExists("copilot")) {
+    const installCopilot = await p.confirm({
+      message: "copilot is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installCopilot)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installCopilot) {
+      const copilotSpinner = p.spinner();
+      copilotSpinner.start("Installing copilot");
+
+      try {
+        if (commandExists("npm")) {
+          execSync("npm install -g @github/copilot", { stdio: "pipe" });
+          copilotSpinner.stop("copilot installed");
+        } else {
+          copilotSpinner.stop("Could not install copilot");
+          p.log.warn(
+            "Please install npm, then run: npm install -g @github/copilot",
+          );
+        }
+      } catch (e) {
+        copilotSpinner.stop("copilot installation failed");
+        p.log.warn(
+          "You can install it manually later: npm install -g @github/copilot",
         );
       }
     }
@@ -813,6 +850,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
     const mode = readConfigValue("default");
     const detected = [];
     for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
+    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot"]) {
       if (commandExists(tool)) detected.push(tool);
     }
 
@@ -974,6 +1012,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           ``,
           `  ${pc.bold("AI CLI tools:")}`,
           ...["lash", "claude", "opencode", "gemini", "codex", "hermes"].map((t) =>
+          ...["lash", "claude", "opencode", "gemini", "codex", "copilot"].map((t) =>
             commandExists(t)
               ? `    ${pc.green("✓")} ${t}`
               : `    ${pc.dim("○")} ${pc.dim(t)}`,

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -166,6 +166,7 @@ const TOOLS = [
   { value: "codex", label: "codex", hint: "OpenAI Codex CLI" },
   { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
   { value: "copilot", label: "copilot", hint: "GitHub Copilot CLI" },
+  { value: "amp", label: "amp", hint: "Sourcegraph Amp CLI" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -415,6 +416,7 @@ async function install() {
   let detected = [];
   for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
   for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot"]) {
+  for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot", "amp"]) {
     if (commandExists(tool)) {
       detected.push(tool);
     }
@@ -620,6 +622,41 @@ async function install() {
         copilotSpinner.stop("copilot installation failed");
         p.log.warn(
           "You can install it manually later: gh extension install github/gh-copilot",
+        );
+      }
+    }
+  }
+
+  // Offer to install amp if selected but not installed
+  if (selectedTool === "amp" && !commandExists("amp")) {
+    const installAmp = await p.confirm({
+      message: "amp is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installAmp)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installAmp) {
+      const ampSpinner = p.spinner();
+      ampSpinner.start("Installing amp");
+
+      try {
+        if (commandExists("npm")) {
+          execSync("npm install -g @sourcegraph/amp", { stdio: "pipe" });
+          ampSpinner.stop("amp installed");
+        } else {
+          ampSpinner.stop("Could not install amp");
+          p.log.warn(
+            "Please install npm, then run: npm install -g @sourcegraph/amp",
+          );
+        }
+      } catch (e) {
+        ampSpinner.stop("amp installation failed");
+        p.log.warn(
+          "You can install it manually later: npm install -g @sourcegraph/amp",
         );
       }
     }
@@ -851,6 +888,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
     const detected = [];
     for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "hermes"]) {
     for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot"]) {
+    for (const tool of ["lash", "claude", "opencode", "gemini", "codex", "copilot", "amp"]) {
       if (commandExists(tool)) detected.push(tool);
     }
 
@@ -1013,6 +1051,7 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           `  ${pc.bold("AI CLI tools:")}`,
           ...["lash", "claude", "opencode", "gemini", "codex", "hermes"].map((t) =>
           ...["lash", "claude", "opencode", "gemini", "codex", "copilot"].map((t) =>
+          ...["lash", "claude", "opencode", "gemini", "codex", "copilot", "amp"].map((t) =>
             commandExists(t)
               ? `    ${pc.green("✓")} ${t}`
               : `    ${pc.dim("○")} ${pc.dim(t)}`,

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -607,19 +607,19 @@ async function install() {
       copilotSpinner.start("Installing copilot");
 
       try {
-        if (commandExists("npm")) {
-          execSync("npm install -g @github/copilot", { stdio: "pipe" });
+        if (commandExists("gh")) {
+          execSync("gh extension install github/gh-copilot", { stdio: "pipe" });
           copilotSpinner.stop("copilot installed");
         } else {
           copilotSpinner.stop("Could not install copilot");
           p.log.warn(
-            "Please install npm, then run: npm install -g @github/copilot",
+            "Please install the GitHub CLI (gh), then run: gh extension install github/gh-copilot",
           );
         }
       } catch (e) {
         copilotSpinner.stop("copilot installation failed");
         p.log.warn(
-          "You can install it manually later: npm install -g @github/copilot",
+          "You can install it manually later: gh extension install github/gh-copilot",
         );
       }
     }


### PR DESCRIPTION
## Summary

Adds [Sourcegraph Amp](https://ampcode.com) as a supported AI CLI backend for Lacy Shell, following the same pattern as the GitHub Copilot integration.

Closes [LAC-1147](https://paperclip.build/LAC/issues/LAC-1147)

## Changes

- **`lib/core/constants.sh`** — Added `amp` to `LACY_TOOL_LIST`
- **`lib/core/mcp.sh`** — Added `amp -x` to `lacy_tool_cmd()`, `amp --continue` to `lacy_resume_cmd()`, and amp to no-tool install hints
- **`lib/core/preheat.sh`** — Added `amp` to `_lacy_get_current_tool()` detection, `_lacy_save_last_session()`, and `lacy_session_resume()` (generic/stateless path, same as codex/copilot)
- **`lib/core/commands.sh`** — Added `amp` to `tool set` usage text
- **`bin/lacy`** — Added `amp` (and missing `copilot`) to doctor/status tool lists and setup_tool selection menu
- **`packages/lacy/index.mjs`** — Added `amp` to TOOLS list, all three detection loops, auto-install prompt, and status display
- **`CLAUDE.md`** — Added amp to supported tools table

## Integration Spec

| | |
|---|---|
| Single-shot | `amp -x "query"` |
| Resume | `amp --continue` |
| Install | `npm install -g @sourcegraph/amp` |
| Session handling | Generic (stateless, same as codex/copilot) |

## Test Plan

- [ ] `tool set amp` switches active tool
- [ ] `tool` shows amp as active with correct command (`amp -x`)
- [ ] Query routes correctly via `amp -x`
- [ ] `/new` clears session state
- [ ] `/resume` calls `amp --continue`
- [ ] Node installer detects amp if installed, shows it in tool list
- [ ] Node installer offers amp install prompt when selected but not installed
- [ ] `lacy doctor` detects amp binary
- [ ] `lacy status` shows amp in AI CLI tools list