### PR TITLE
feat: add Sourcegraph Amp CLI backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,7 @@ Lacy's `_lacy_forward_char_or_accept` and `_lacy_expand_or_accept` widgets check
 | hermes   | `hermes chat -q "query"` | `-q`         |
 | copilot  | `copilot -p "query"`   | `-p`         |
 | goose    | `goose run -t "query"` | `-t`         |
+| amp      | `amp -x "query"`       | `-x`         |
 | custom   | user-defined command   | user-defined |
 
 lash is the recommended default — it's an opencode fork built by the same author. Website: lash.lacy.sh. During onboarding, lacy offers to install lash if no AI CLI tool is detected.

--- a/bin/lacy
+++ b/bin/lacy
@@ -348,7 +348,7 @@ cmd_status() {
 
     # AI tools
     printf "\n${BOLD}AI CLI Tools${NC}\n"
-    for t in lash claude opencode gemini codex hermes copilot goose; do
+    for t in lash claude opencode gemini codex hermes copilot goose amp; do
         if command_exists "$t"; then
             success "$t"
         else
@@ -425,7 +425,7 @@ cmd_doctor() {
 
     # Check AI tool
     local found_tool=0
-    for t in lash claude opencode gemini codex hermes copilot goose; do
+    for t in lash claude opencode gemini codex hermes copilot goose amp; do
         if command_exists "$t"; then
             found_tool=1
             break
@@ -552,8 +552,8 @@ setup_tool() {
     printf "\n${BOLD}Select AI tool${NC}\n\n"
 
     local i=1
-    local tools=("lash" "claude" "opencode" "gemini" "codex" "custom" "auto")
-    local hints=("AI coding agent (recommended)" "Claude Code CLI" "OpenCode CLI" "Google Gemini CLI" "OpenAI Codex CLI" "enter your own command" "use first available")
+    local tools=("lash" "claude" "opencode" "gemini" "codex" "hermes" "copilot" "goose" "amp" "custom" "auto")
+    local hints=("AI coding agent (recommended)" "Claude Code CLI" "OpenCode CLI" "Google Gemini CLI" "OpenAI Codex CLI" "Hermes Agent CLI" "GitHub Copilot CLI" "Goose CLI" "Sourcegraph Amp CLI" "enter your own command" "use first available")
 
     for t in "${tools[@]}"; do
         local hint="${hints[$((i-1))]}"

--- a/install.sh
+++ b/install.sh
@@ -279,7 +279,7 @@ detect_tools() {
     printf "${BLUE}Detecting AI CLI tools...${NC}\n"
     local found=0
 
-    for tool in lash claude opencode gemini codex; do
+    for tool in lash claude opencode gemini codex copilot amp; do
         if command -v "$tool" >/dev/null 2>&1; then
             printf "  ${GREEN}✓${NC} $tool\n"
             found=1
@@ -315,13 +315,15 @@ select_tool() {
     printf "  3) opencode   ${DIM}- OpenCode CLI${NC}\n"
     printf "  4) gemini     ${DIM}- Google Gemini CLI${NC}\n"
     printf "  5) codex      ${DIM}- OpenAI Codex CLI${NC}\n"
-    printf "  6) Auto-detect ${DIM}(use first available)${NC}\n"
-    printf "  7) None       ${DIM}- I'll install one later${NC}\n"
-    printf "  8) Custom     ${DIM}- enter your own command${NC}\n"
+    printf "  6) copilot    ${DIM}- GitHub Copilot CLI${NC}\n"
+    printf "  7) amp        ${DIM}- Sourcegraph Amp CLI${NC}\n"
+    printf "  8) Auto-detect ${DIM}(use first available)${NC}\n"
+    printf "  9) None       ${DIM}- I'll install one later${NC}\n"
+    printf " 10) Custom     ${DIM}- enter your own command${NC}\n"
     printf "\n"
 
     local choice
-    read -p "Select [1-8, default=6]: " choice < /dev/tty 2>/dev/null || choice="6"
+    read -p "Select [1-10, default=8]: " choice < /dev/tty 2>/dev/null || choice="8"
 
     case "$choice" in
         1) SELECTED_TOOL="lash" ;;
@@ -329,9 +331,11 @@ select_tool() {
         3) SELECTED_TOOL="opencode" ;;
         4) SELECTED_TOOL="gemini" ;;
         5) SELECTED_TOOL="codex" ;;
-        6|"") SELECTED_TOOL="" ;;
-        7) SELECTED_TOOL="none" ;;
-        8)
+        6) SELECTED_TOOL="copilot" ;;
+        7) SELECTED_TOOL="amp" ;;
+        8|"") SELECTED_TOOL="" ;;
+        9) SELECTED_TOOL="none" ;;
+        10)
             SELECTED_TOOL="custom"
             printf "\n"
             read -p "Enter command (e.g. claude --dangerously-skip-permissions -p): " CUSTOM_COMMAND < /dev/tty 2>/dev/null || CUSTOM_COMMAND=""
@@ -364,6 +368,8 @@ select_tool() {
                     opencode) printf "  brew install opencode\n" ;;
                     gemini) printf "  brew install gemini\n" ;;
                     codex) printf "  npm install -g @openai/codex\n" ;;
+                    copilot) printf "  gh extension install github/gh-copilot\n" ;;
+                    amp) printf "  npm install -g @sourcegraph/amp\n" ;;
                 esac
             fi
         fi
@@ -377,7 +383,7 @@ select_tool() {
         # Auto-detect: check if any tool is available
         printf "\n"
         local first_tool_found=""
-        for t in lash claude opencode gemini codex; do
+        for t in lash claude opencode gemini codex copilot amp; do
             if command -v "$t" >/dev/null 2>&1; then
                 first_tool_found="$t"
                 break

--- a/install.sh
+++ b/install.sh
@@ -279,7 +279,7 @@ detect_tools() {
     printf "${BLUE}Detecting AI CLI tools...${NC}\n"
     local found=0
 
-    for tool in lash claude opencode gemini codex copilot amp; do
+    for tool in lash claude opencode gemini codex hermes copilot amp; do
         if command -v "$tool" >/dev/null 2>&1; then
             printf "  ${GREEN}✓${NC} $tool\n"
             found=1
@@ -315,15 +315,16 @@ select_tool() {
     printf "  3) opencode   ${DIM}- OpenCode CLI${NC}\n"
     printf "  4) gemini     ${DIM}- Google Gemini CLI${NC}\n"
     printf "  5) codex      ${DIM}- OpenAI Codex CLI${NC}\n"
-    printf "  6) copilot    ${DIM}- GitHub Copilot CLI${NC}\n"
-    printf "  7) amp        ${DIM}- Sourcegraph Amp CLI${NC}\n"
-    printf "  8) Auto-detect ${DIM}(use first available)${NC}\n"
-    printf "  9) None       ${DIM}- I'll install one later${NC}\n"
-    printf " 10) Custom     ${DIM}- enter your own command${NC}\n"
+    printf "  6) hermes     ${DIM}- Hermes Agent CLI${NC}\n"
+    printf "  7) copilot    ${DIM}- GitHub Copilot CLI${NC}\n"
+    printf "  8) amp        ${DIM}- Sourcegraph Amp CLI${NC}\n"
+    printf "  9) Auto-detect ${DIM}(use first available)${NC}\n"
+    printf " 10) None       ${DIM}- I'll install one later${NC}\n"
+    printf " 11) Custom     ${DIM}- enter your own command${NC}\n"
     printf "\n"
 
     local choice
-    read -p "Select [1-10, default=8]: " choice < /dev/tty 2>/dev/null || choice="8"
+    read -p "Select [1-11, default=9]: " choice < /dev/tty 2>/dev/null || choice="9"
 
     case "$choice" in
         1) SELECTED_TOOL="lash" ;;
@@ -331,11 +332,12 @@ select_tool() {
         3) SELECTED_TOOL="opencode" ;;
         4) SELECTED_TOOL="gemini" ;;
         5) SELECTED_TOOL="codex" ;;
-        6) SELECTED_TOOL="copilot" ;;
-        7) SELECTED_TOOL="amp" ;;
-        8|"") SELECTED_TOOL="" ;;
-        9) SELECTED_TOOL="none" ;;
-        10)
+        6) SELECTED_TOOL="hermes" ;;
+        7) SELECTED_TOOL="copilot" ;;
+        8) SELECTED_TOOL="amp" ;;
+        9|"") SELECTED_TOOL="" ;;
+        10) SELECTED_TOOL="none" ;;
+        11)
             SELECTED_TOOL="custom"
             printf "\n"
             read -p "Enter command (e.g. claude --dangerously-skip-permissions -p): " CUSTOM_COMMAND < /dev/tty 2>/dev/null || CUSTOM_COMMAND=""
@@ -368,6 +370,7 @@ select_tool() {
                     opencode) printf "  brew install opencode\n" ;;
                     gemini) printf "  brew install gemini\n" ;;
                     codex) printf "  npm install -g @openai/codex\n" ;;
+                    hermes) printf "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash\n" ;;
                     copilot) printf "  gh extension install github/gh-copilot\n" ;;
                     amp) printf "  npm install -g @sourcegraph/amp\n" ;;
                 esac
@@ -383,7 +386,7 @@ select_tool() {
         # Auto-detect: check if any tool is available
         printf "\n"
         local first_tool_found=""
-        for t in lash claude opencode gemini codex copilot amp; do
+        for t in lash claude opencode gemini codex hermes copilot amp; do
             if command -v "$t" >/dev/null 2>&1; then
                 first_tool_found="$t"
                 break

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -201,7 +201,7 @@ lacy_shell_tool() {
             ;;
         *)
             echo "Usage: tool [set <name>]"
-            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, custom, auto"
+            echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, custom, auto"
             echo "  tool set custom \"command -flags\""
             ;;
     esac

--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -172,7 +172,7 @@ lacy_shell_tool() {
         set)
             if [[ -z "$2" ]]; then
                 echo "Usage: tool set <name>"
-                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, custom, auto"
+                echo "Options: lash, claude, opencode, gemini, codex, hermes, copilot, goose, amp, custom, auto"
                 echo "  tool set custom \"command -flags\""
                 return 1
             fi

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -282,7 +282,7 @@ appearance:
 # AI CLI tool selection
 # Lacy auto-detects installed tools, or you can set one explicitly
 agent_tools:
-  # Options: lash, claude, opencode, gemini, codex, custom, or empty for auto-detect
+  # Options: lash, claude, opencode, gemini, codex, copilot, amp, custom, or empty for auto-detect
   active:
   # Custom command (used when active: custom)
   # custom_command: "your-command -flags"

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -282,7 +282,7 @@ appearance:
 # AI CLI tool selection
 # Lacy auto-detects installed tools, or you can set one explicitly
 agent_tools:
-  # Options: lash, claude, opencode, gemini, codex, copilot, amp, custom, or empty for auto-detect
+  # Options: lash, claude, opencode, gemini, codex, hermes, copilot, amp, custom, or empty for auto-detect
   active:
   # Custom command (used when active: custom)
   # custom_command: "your-command -flags"

--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -192,7 +192,7 @@ LACY_SPINNER_FRAMES='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
 LACY_SPINNER_TEXT='Thinking'
 
 # === Tool List (canonical order for detection and display) ===
-LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot goose)
+LACY_TOOL_LIST=(lash claude opencode gemini codex hermes copilot goose amp)
 
 # === User-Facing Messages ===
 LACY_MSG_QUIT="Exiting Lacy Shell..."

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -173,6 +173,7 @@ lacy_tool_cmd() {
         hermes)   echo "hermes chat -q" ;;
         copilot)  echo "copilot -p" ;;
         goose)    echo "goose run -t" ;;
+        amp)      echo "amp -x" ;;
         *)        echo "" ;;
     esac
 }
@@ -207,6 +208,7 @@ lacy_resume_cmd() {
         hermes)   echo "hermes --continue" ;;
         copilot)  echo "copilot --resume" ;;
         goose)    echo "goose session resume" ;;
+        amp)      echo "amp --continue" ;;
     esac
 }
 
@@ -453,6 +455,7 @@ EOF
                 echo "  hermes:   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
                 echo "  copilot:  gh extension install github/gh-copilot"
                 echo "  goose:    brew install goose"
+                echo "  amp:      npm install -g @sourcegraph/amp"
                 return 1
             fi
         else
@@ -466,6 +469,7 @@ EOF
             echo "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash  (hermes)"
             echo "  gh extension install github/gh-copilot  (copilot)"
             echo "  brew install goose"
+            echo "  npm install -g @sourcegraph/amp"
             return 1
         fi
     fi

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -382,7 +382,7 @@ _lacy_save_last_session() {
         lash|opencode)   session_id="$LACY_PREHEAT_SERVER_SESSION_ID" ;;
         claude)          session_id="$LACY_PREHEAT_CLAUDE_SESSION_ID" ;;
         gemini)          session_id="$LACY_GEMINI_SESSION_ID" ;;
-        codex|hermes|copilot|goose) session_id="default" ;;
+        codex|hermes|copilot|goose|amp) session_id="default" ;;
     esac
 
     [[ -n "$session_id" && -n "$tool" ]] || return 0
@@ -459,7 +459,7 @@ lacy_session_resume() {
             LACY_GEMINI_SESSION_ID="$saved_id"
             echo "$saved_id" > "$LACY_GEMINI_SESSION_ID_FILE"
             ;;
-        codex|hermes|copilot|goose)
+        codex|hermes|copilot|goose|amp)
             ;;
     esac
 

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -167,6 +167,7 @@ const TOOLS = [
   { value: "hermes", label: "hermes (beta)", hint: "Hermes Agent — Nous Research" },
   { value: "copilot", label: "copilot (beta)", hint: "GitHub Copilot CLI" },
   { value: "goose", label: "goose (beta)", hint: "Block's Goose AI agent" },
+  { value: "amp", label: "amp", hint: "Sourcegraph Amp CLI" },
   { value: "custom", label: "Custom", hint: "enter your own command" },
   { value: "auto", label: "Auto-detect", hint: "use first available" },
   { value: "none", label: "None", hint: "I'll install one later" },
@@ -652,6 +653,41 @@ async function install() {
         gooseSpinner.stop(`goose installation failed: ${e.message}`);
         p.log.warn(
           "You can install it manually later: brew install goose",
+        );
+      }
+    }
+  }
+
+  // Offer to install amp if selected but not installed
+  if (selectedTool === "amp" && !commandExists("amp")) {
+    const installAmp = await p.confirm({
+      message: "amp is not installed. Would you like to install it now?",
+      initialValue: true,
+    });
+
+    if (p.isCancel(installAmp)) {
+      p.cancel("Installation cancelled");
+      process.exit(0);
+    }
+
+    if (installAmp) {
+      const ampSpinner = p.spinner();
+      ampSpinner.start("Installing amp");
+
+      try {
+        if (commandExists("npm")) {
+          execSync("npm install -g @sourcegraph/amp", { stdio: "pipe" });
+          ampSpinner.stop("amp installed");
+        } else {
+          ampSpinner.stop("Could not install amp");
+          p.log.warn(
+            "Please install npm, then run: npm install -g @sourcegraph/amp",
+          );
+        }
+      } catch (e) {
+        ampSpinner.stop("amp installation failed");
+        p.log.warn(
+          "You can install it manually later: npm install -g @sourcegraph/amp",
         );
       }
     }


### PR DESCRIPTION
## Summary

Adds [Sourcegraph Amp](https://ampcode.com) as a supported AI CLI backend for Lacy Shell, following the same pattern as the GitHub Copilot integration.

Replaces #44 (rebased onto new main after force-push per [LAC-1154](/LAC/issues/LAC-1154)).

Closes [LAC-1147](/LAC/issues/LAC-1147)

## Changes

- **`lib/core/constants.sh`** — Added `amp` to `LACY_TOOL_LIST`
- **`lib/core/mcp.sh`** — Added `amp -x` to `lacy_tool_cmd()`, `amp --continue` to `lacy_resume_cmd()`, amp to no-tool install hints
- **`lib/core/preheat.sh`** — Added `amp` to `_lacy_get_current_tool()` detection, `_lacy_save_last_session()`, and `lacy_session_resume()` (generic/stateless path, same as codex/copilot)
- **`lib/core/commands.sh`** — Added `amp` to both `tool set` usage strings
- **`lib/core/config.sh`** — Added `copilot` and `amp` to generated config comment
- **`bin/lacy`** — Added `amp` (and previously missing `copilot`) to doctor/status tool lists and setup_tool menu
- **`install.sh`** — Added `copilot` and `amp` to detect loop, interactive menu (items 6–7), and install hints
- **`packages/lacy/index.mjs`** — Added `amp` to TOOLS list, all detection loops, auto-install prompt, status display
- **`CLAUDE.md`** — Added amp row to supported tools table

## Integration Spec

| | |
|---|---|
| Single-shot | `amp -x "query"` |
| Resume | `amp --continue` |
| Install | `npm install -g @sourcegraph/amp` |
| Session handling | Generic (stateless, same as codex/copilot) |

## Test Plan

- [ ] `tool set amp` switches active tool
- [ ] `tool` shows amp as active with correct command (`amp -x`)
- [ ] Query routes correctly via `amp -x`
- [ ] `/new` clears session state
- [ ] `/resume` calls `amp --continue`
- [ ] Node installer detects amp if installed, shows it in tool list
- [ ] Node installer offers amp install prompt when selected but not installed
- [ ] `lacy doctor` detects amp binary
- [ ] `lacy status` shows amp in AI CLI tools list