### PR TITLE
feat(spinner): add dots and ascii spinner styles

### DIFF
--- a/lib/core/animations.sh
+++ b/lib/core/animations.sh
@@ -14,7 +14,7 @@
 
 # Available animation names
 LACY_SPINNER_ANIMATIONS=(
-    "braille" "braillewave" "dna" "scan" "rain" "scanline"
+    "braille" "dots" "ascii" "braillewave" "dna" "scan" "rain" "scanline"
     "pulse" "snake" "sparkle" "cascade" "columns" "orbit"
     "breathe" "waverows" "checkerboard" "helix" "fillsweep" "diagswipe"
 )
@@ -41,6 +41,15 @@ lacy_set_spinner_animation() {
             # Classic rotating dots
             LACY_SPINNER_ANIM=("⠋⠀⠀⠀" "⠙⠀⠀⠀" "⠹⠀⠀⠀" "⠸⠀⠀⠀" "⠼⠀⠀⠀" "⠴⠀⠀⠀"
                 "⠦⠀⠀⠀" "⠧⠀⠀⠀" "⠇⠀⠀⠀" "⠏⠀⠀⠀")
+            ;;
+        dots)
+            # Single dot traveling all 8 braille positions
+            LACY_SPINNER_ANIM=("⠁⠀⠀⠀" "⠂⠀⠀⠀" "⠄⠀⠀⠀" "⡀⠀⠀⠀" "⢀⠀⠀⠀" "⠠⠀⠀⠀"
+                "⠐⠀⠀⠀" "⠈⠀⠀⠀")
+            ;;
+        ascii)
+            # ASCII-only fallback for terminals without Unicode
+            LACY_SPINNER_ANIM=("|   " "/   " "-   " "\\   ")
             ;;
         braillewave)
             # Traveling dot wave

--- a/lib/core/config.sh
+++ b/lib/core/config.sh
@@ -298,9 +298,10 @@ agent_tools:
 #   output_lines: 50      # Max lines to include (truncates from top)
 
 # Spinner animation style
-# Options: braille, braillewave, dna, scan, rain, scanline, pulse, snake, sparkle,
-#          cascade, columns, orbit, breathe, waverows, checkerboard, helix, fillsweep,
-#          diagswipe, random (picks a different one each query)
+# Options: braille (default), dots, ascii (no Unicode), braillewave, dna, scan,
+#          rain, scanline, pulse, snake, sparkle, cascade, columns, orbit, breathe,
+#          waverows, checkerboard, helix, fillsweep, diagswipe,
+#          random (picks a different one each query)
 # spinner:
 #   style: random
 


### PR DESCRIPTION
## Summary
- Adds `dots` style: single braille dot traveling all 8 positions (minimal, clean)
- Adds `ascii` style: classic `| / - \` for terminals without Unicode support
- Updates config template comments to list the new options

Closes #33

## Configuration

```yaml
spinner:
  style: dots    # or: ascii, braille, random, etc.
```

## Test plan
- [ ] `LACY_SPINNER_STYLE=dots` shows single traveling dot
- [ ] `LACY_SPINNER_STYLE=ascii` shows `| / - \` rotation
- [ ] `LACY_SPINNER_STYLE=random` still picks from all styles including new ones
- [ ] Preview works: source the plugin and run `lacy_preview_all_spinners`