### PR TITLE
feat(detection): add ~40 agent words for better NL routing

### DIFF
--- a/lib/core/constants.sh
+++ b/lib/core/constants.sh
@@ -72,15 +72,17 @@ LACY_AGENT_WORDS=(
     "yes" "yeah" "yep" "yup" "sure" "ok" "okay" "alright"
     "absolutely" "definitely" "certainly" "indeed" "correct" "right" "exactly"
     "perfect" "agreed" "affirmative" "totally" "clearly" "obviously" "lgtm"
+    "roger" "understood" "acknowledged" "gotcha"
     # negations
-    "no" "nope" "nah" "never" "wrong" "disagree"
+    "no" "nope" "nah" "never" "wrong" "disagree" "nay" "meh"
     # gratitude
-    "thanks" "thank" "thx" "ty" "cheers" "appreciated"
+    "thanks" "thank" "thx" "ty" "cheers" "appreciated" "kudos" "congrats" "bravo"
     # reactions
     "great" "good" "nice" "cool" "awesome" "amazing" "wonderful" "brilliant"
     "excellent" "fantastic" "sweet" "neat" "beautiful" "gorgeous" "impressive"
     "incredible" "outstanding" "superb" "marvelous" "magnificent" "stellar"
     "phenomenal" "terrific" "splendid" "fine" "solid" "dope" "sick" "fire" "lit" "rad" "legit"
+    "noice" "yay" "hooray" "woah"
     # greetings/closings
     "hey" "hi" "hello" "howdy" "sup" "yo" "bye" "goodbye" "cya" "later"
     # conversational
@@ -89,16 +91,22 @@ LACY_AGENT_WORDS=(
     "meanwhile" "honestly" "basically" "literally" "actually" "really"
     "seriously" "hopefully" "unfortunately" "apparently"
     "supposedly" "probably" "maybe" "perhaps" "possibly"
+    "sheesh" "geez" "oof" "ouch" "bummer" "duh"
+    # internet/chat shorthand
+    "lol" "haha" "heh" "omg" "wtf" "idk" "fyi" "btw" "imho" "imo" "tbh" "pls" "plz"
     # action/intent
     "stop" "hold" "pause" "cancel" "abort" "skip" "continue" "proceed"
     "next" "again" "redo" "undo" "retry"
     "explain" "elaborate" "clarify" "summarize" "describe" "show" "tell"
+    "suggest" "recommend" "consider" "imagine" "suppose"
     # question words
     "why" "how" "what" "when" "where" "who" "which" "whom" "whose"
     "can" "could" "would" "should" "will" "shall" "may" "might" "must"
     "does" "did" "is" "are" "was" "were" "has" "have" "had"
     # programming verbs used conversationally (not valid commands on common systems)
-    "refactor" "optimize" "scaffold"
+    "refactor" "optimize" "scaffold" "debug" "deploy" "implement"
+    "migrate" "lint" "render" "integrate" "iterate"
+    "diagnose" "troubleshoot" "hotfix" "rollback" "revert"
 )
 
 # Natural language markers — common English words unusual as shell arguments.

--- a/tests/test_core.sh
+++ b/tests/test_core.sh
@@ -113,6 +113,41 @@ assert_eq "how → agent" "agent" "$(lacy_shell_classify_input 'how')"
 assert_eq "no → agent" "agent" "$(lacy_shell_classify_input 'no')"
 assert_eq "nope → agent" "agent" "$(lacy_shell_classify_input 'nope')"
 
+# New agent words — affirmations/reactions
+assert_eq "gotcha → agent" "agent" "$(lacy_shell_classify_input 'gotcha')"
+assert_eq "roger → agent" "agent" "$(lacy_shell_classify_input 'roger')"
+assert_eq "understood → agent" "agent" "$(lacy_shell_classify_input 'understood')"
+assert_eq "kudos → agent" "agent" "$(lacy_shell_classify_input 'kudos')"
+assert_eq "noice → agent" "agent" "$(lacy_shell_classify_input 'noice')"
+
+# New agent words — conversational/reactions
+assert_eq "sheesh → agent" "agent" "$(lacy_shell_classify_input 'sheesh')"
+assert_eq "oof → agent" "agent" "$(lacy_shell_classify_input 'oof')"
+assert_eq "meh → agent" "agent" "$(lacy_shell_classify_input 'meh')"
+assert_eq "duh → agent" "agent" "$(lacy_shell_classify_input 'duh')"
+assert_eq "bummer → agent" "agent" "$(lacy_shell_classify_input 'bummer')"
+
+# New agent words — internet/chat shorthand
+assert_eq "lol → agent" "agent" "$(lacy_shell_classify_input 'lol')"
+assert_eq "omg → agent" "agent" "$(lacy_shell_classify_input 'omg')"
+assert_eq "idk → agent" "agent" "$(lacy_shell_classify_input 'idk')"
+assert_eq "btw → agent" "agent" "$(lacy_shell_classify_input 'btw')"
+assert_eq "tbh → agent" "agent" "$(lacy_shell_classify_input 'tbh')"
+assert_eq "fyi → agent" "agent" "$(lacy_shell_classify_input 'fyi')"
+
+# New agent words — programming verbs
+assert_eq "debug → agent" "agent" "$(lacy_shell_classify_input 'debug')"
+assert_eq "deploy → agent" "agent" "$(lacy_shell_classify_input 'deploy')"
+assert_eq "implement → agent" "agent" "$(lacy_shell_classify_input 'implement')"
+assert_eq "diagnose → agent" "agent" "$(lacy_shell_classify_input 'diagnose')"
+assert_eq "troubleshoot → agent" "agent" "$(lacy_shell_classify_input 'troubleshoot')"
+assert_eq "rollback → agent" "agent" "$(lacy_shell_classify_input 'rollback')"
+
+# New agent words — action/intent
+assert_eq "suggest → agent" "agent" "$(lacy_shell_classify_input 'suggest')"
+assert_eq "recommend → agent" "agent" "$(lacy_shell_classify_input 'recommend')"
+assert_eq "imagine → agent" "agent" "$(lacy_shell_classify_input 'imagine')"
+
 # Agent words — with trailing punctuation
 assert_eq "why? → agent" "agent" "$(lacy_shell_classify_input 'why?')"
 assert_eq "how? → agent" "agent" "$(lacy_shell_classify_input 'how?')"


### PR DESCRIPTION
## Summary

- Adds ~40 new words to `LACY_AGENT_WORDS` in `lib/core/constants.sh` for improved natural language detection accuracy
- Words span affirmations (`gotcha`, `roger`), reactions (`oof`, `sheesh`), internet shorthand (`lol`, `omg`, `idk`, `btw`, `tbh`), programming verbs (`debug`, `deploy`, `implement`, `diagnose`, `troubleshoot`), and action/intent (`suggest`, `recommend`)
- All candidates verified with `command -v` to ensure they don't shadow real shell commands
- 25 new test assertions added covering representative words from each category

## Test plan

- [x] `bash tests/test_core.sh` — 158 passed, 0 failed
- [x] `zsh tests/test_core.sh` — 158 passed, 0 failed
- [x] All candidate words verified as non-commands via `command -v`

Closes #35