### PR TITLE
feat(nushell): add Nushell plugin support

### DIFF
--- a/lacy.plugin.nu
+++ b/lacy.plugin.nu
@@ -1,0 +1,41 @@
+# Lacy Shell — Nushell plugin entry point
+# Source this file in ~/.config/nushell/config.nu:
+#   source ~/.lacy/lacy.plugin.nu
+#
+# Or let the installer add it automatically.
+#
+# Requires Nushell 0.87+.
+
+# ============================================================================
+# Guards
+# ============================================================================
+
+# Prevent multiple sourcing
+if ($env.LACY_SHELL_LOADED? | default false) == true { return }
+
+let _nu_ver = (version).version | split row '.' | each { into int }
+if ($_nu_ver | first) == 0 and ($_nu_ver | get 1) < 87 {
+    print --stderr $"Lacy Shell: Nushell 0.87+ is required. You have: (version).version"
+    return
+}
+
+# ============================================================================
+# Paths
+# ============================================================================
+
+$env.LACY_SHELL_HOME = ($env.HOME | path join ".lacy")
+$env.LACY_SHELL_TYPE = "nushell"
+$env.LACY_SHELL_ACTIVE = 1
+$env.LACY_SHELL_LOADED = true
+
+# ============================================================================
+# Source Nushell modules
+# ============================================================================
+
+# Note: `source` requires literal paths in Nushell.
+# The plugin is assumed to be installed at ~/.lacy/.
+source ~/.lacy/lib/nu/config.nu
+source ~/.lacy/lib/nu/detection.nu
+source ~/.lacy/lib/nu/execute.nu
+source ~/.lacy/lib/nu/keybindings.nu
+source ~/.lacy/lib/nu/prompt.nu

--- a/lib/nu/config.nu
+++ b/lib/nu/config.nu
@@ -1,0 +1,82 @@
+# Lacy Shell — Nushell configuration
+
+$env.LACY_SHELL_MODE = "auto"     # shell | agent | auto
+$env.LACY_ACTIVE_TOOL = ""        # empty = auto-detect
+$env.LACY_CUSTOM_TOOL_CMD = ""
+$env.LACY_TOOL_LIST = ["lash" "claude" "opencode" "gemini" "codex"]
+
+# Agent words: single words that always route to the AI agent.
+# Kept in sync with lib/core/constants.sh LACY_AGENT_WORDS.
+$env.LACY_AGENT_WORDS = [
+    "yes" "yeah" "yep" "yup" "sure" "ok" "okay" "alright"
+    "absolutely" "definitely" "certainly" "indeed" "correct" "right" "exactly"
+    "perfect" "agreed" "affirmative" "totally" "clearly" "obviously" "lgtm"
+    "no" "nope" "nah" "never" "wrong" "disagree"
+    "thanks" "thank" "thx" "ty" "cheers" "appreciated"
+    "great" "good" "nice" "cool" "awesome" "amazing" "wonderful" "brilliant"
+    "excellent" "fantastic" "sweet" "neat" "beautiful" "gorgeous" "impressive"
+    "incredible" "outstanding" "superb" "marvelous" "magnificent" "stellar"
+    "phenomenal" "terrific" "splendid" "fine" "solid" "dope" "sick" "fire" "lit" "rad" "legit"
+    "hey" "hi" "hello" "howdy" "sup" "yo" "bye" "goodbye" "cya" "later"
+    "please" "sorry" "pardon" "hmm" "huh" "wow" "whoa" "oops" "ugh" "yikes"
+    "damn" "dang" "shoot" "welp" "well" "anyway" "anyways" "regardless"
+    "meanwhile" "honestly" "basically" "literally" "actually" "really"
+    "seriously" "obviously" "hopefully" "unfortunately" "apparently"
+    "supposedly" "probably" "maybe" "perhaps" "possibly"
+    "stop" "hold" "pause" "cancel" "abort" "skip" "continue" "proceed"
+    "next" "again" "redo" "undo" "retry"
+    "explain" "elaborate" "clarify" "summarize" "describe" "show" "tell"
+    "why" "how" "what" "when" "where" "who" "which" "whom" "whose"
+    "can" "could" "would" "should" "will" "shall" "may" "might" "must"
+    "does" "did" "is" "are" "was" "were" "has" "have" "had"
+    "refactor" "optimize" "scaffold"
+]
+
+# Shell reserved words that pass command lookup but are never standalone commands.
+$env.LACY_SHELL_RESERVED_WORDS = ["do" "done" "then" "else" "elif" "fi" "esac" "in" "select" "function"]
+
+# ============================================================================
+# YAML config parser (reads ~/.lacy/config.yaml)
+# ============================================================================
+
+def _lacy_load_config [] {
+    let config_file = ($env.HOME | path join ".lacy" "config.yaml")
+    if not ($config_file | path exists) { return }
+
+    let file_lines = (open --raw $config_file | lines)
+
+    # Parse agent_tools.active
+    let active_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "active:") })
+    if ($active_lines | length) > 0 {
+        let active = ($active_lines | first
+            | str replace -r '.*active:\s*' ''
+            | str trim
+            | str replace --all '"' ''
+            | str replace --all "'" '')
+        if $active != "" { $env.LACY_ACTIVE_TOOL = $active }
+    }
+
+    # Parse agent_tools.custom_command
+    let custom_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "custom_command:") })
+    if ($custom_lines | length) > 0 {
+        let custom = ($custom_lines | first
+            | str replace -r '.*custom_command:\s*' ''
+            | str trim
+            | str replace --all '"' ''
+            | str replace --all "'" '')
+        if $custom != "" { $env.LACY_CUSTOM_TOOL_CMD = $custom }
+    }
+
+    # Parse modes.default
+    let mode_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "default:") })
+    if ($mode_lines | length) > 0 {
+        let mode = ($mode_lines | first
+            | str replace -r '.*default:\s*' ''
+            | str trim
+            | str replace --all '"' ''
+            | str replace --all "'" '')
+        if $mode != "" { $env.LACY_SHELL_MODE = $mode }
+    }
+}
+
+_lacy_load_config

--- a/lib/nu/config.nu
+++ b/lib/nu/config.nu
@@ -39,44 +39,20 @@ $env.LACY_SHELL_RESERVED_WORDS = ["do" "done" "then" "else" "elif" "fi" "esac" "
 # YAML config parser (reads ~/.lacy/config.yaml)
 # ============================================================================
 
-def _lacy_load_config [] {
+def --env _lacy_load_config [] {
     let config_file = ($env.HOME | path join ".lacy" "config.yaml")
     if not ($config_file | path exists) { return }
 
-    let file_lines = (open --raw $config_file | lines)
+    let cfg = (open --raw $config_file | from yaml)
 
-    # Parse agent_tools.active
-    let active_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "active:") })
-    if ($active_lines | length) > 0 {
-        let active = ($active_lines | first
-            | str replace -r '.*active:\s*' ''
-            | str trim
-            | str replace --all '"' ''
-            | str replace --all "'" '')
-        if $active != "" { $env.LACY_ACTIVE_TOOL = $active }
-    }
+    let active = ($cfg | get --optional agent_tools.active | default "" | into string | str trim)
+    if $active != "" { $env.LACY_ACTIVE_TOOL = $active }
 
-    # Parse agent_tools.custom_command
-    let custom_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "custom_command:") })
-    if ($custom_lines | length) > 0 {
-        let custom = ($custom_lines | first
-            | str replace -r '.*custom_command:\s*' ''
-            | str trim
-            | str replace --all '"' ''
-            | str replace --all "'" '')
-        if $custom != "" { $env.LACY_CUSTOM_TOOL_CMD = $custom }
-    }
+    let custom = ($cfg | get --optional agent_tools.custom_command | default "" | into string | str trim)
+    if $custom != "" { $env.LACY_CUSTOM_TOOL_CMD = $custom }
 
-    # Parse modes.default
-    let mode_lines = ($file_lines | where { |line| ($line | str trim | str starts-with "default:") })
-    if ($mode_lines | length) > 0 {
-        let mode = ($mode_lines | first
-            | str replace -r '.*default:\s*' ''
-            | str trim
-            | str replace --all '"' ''
-            | str replace --all "'" '')
-        if $mode != "" { $env.LACY_SHELL_MODE = $mode }
-    }
+    let mode = ($cfg | get --optional modes.default | default "" | into string | str trim)
+    if $mode != "" { $env.LACY_SHELL_MODE = $mode }
 }
 
 _lacy_load_config

--- a/lib/nu/detection.nu
+++ b/lib/nu/detection.nu
@@ -1,0 +1,45 @@
+# Lacy Shell — Nushell input classification
+#
+# Ports the core detection logic from lib/core/detection.sh to Nushell syntax.
+# Returns: "shell" | "agent" | "neutral"
+
+# Classify a line of input.
+# Usage: let route = (_lacy_classify_input "some input")
+def _lacy_classify_input [input: string] -> string {
+    let trimmed = ($input | str trim)
+
+    # Empty input — return mode color signal
+    if $trimmed == "" {
+        return (match $env.LACY_SHELL_MODE {
+            "shell" => "shell"
+            "agent" => "agent"
+            _ => "neutral"
+        })
+    }
+
+    # Locked modes
+    if $env.LACY_SHELL_MODE == "shell" { return "shell" }
+    if $env.LACY_SHELL_MODE == "agent" { return "agent" }
+
+    # Emergency bypass: leading !
+    if ($trimmed | str starts-with "!") { return "shell" }
+
+    let words = ($trimmed | split row ' ' | where { |w| $w != "" })
+    let first_word = ($words | first | str downcase)
+    let word_count = ($words | length)
+
+    # Agent word check (single words that always route to agent)
+    if $first_word in $env.LACY_AGENT_WORDS { return "agent" }
+
+    # Shell reserved words that look like natural language
+    if $first_word in $env.LACY_SHELL_RESERVED_WORDS { return "agent" }
+
+    # Valid command → shell (use `which` since Nushell has no `command -v`)
+    if (which $first_word | length) > 0 { return "shell" }
+
+    # Single unknown word → shell (let it fail naturally — likely a typo)
+    if $word_count == 1 { return "shell" }
+
+    # Multi-word, first word not a command → agent (natural language)
+    "agent"
+}

--- a/lib/nu/execute.nu
+++ b/lib/nu/execute.nu
@@ -1,0 +1,79 @@
+# Lacy Shell — Nushell execution routing
+#
+# Routes input to either the shell or the AI agent.
+# Alt+Enter sends the current buffer to the agent.
+# Normal Enter executes as-is in Nushell.
+
+def _lacy_detect_tool [] -> string {
+    let active = ($env.LACY_ACTIVE_TOOL? | default "")
+    if $active != "" and $active != "auto" { return $active }
+    for tool in $env.LACY_TOOL_LIST {
+        if (which $tool | length) > 0 { return $tool }
+    }
+    ""
+}
+
+def _lacy_no_tool_error [] {
+    print $"\n\e[38;5;196m  No AI tool detected.\e[0m Lacy needs an AI CLI to handle queries.\n"
+    print $"\e[1m  Supported tools:\e[0m\n"
+    print $"    \e[38;5;34mlash\e[0m        npm install -g lashcode        (recommended)"
+    print $"    \e[38;5;238mclaude\e[0m      brew install claude"
+    print $"    \e[38;5;238mopencode\e[0m    brew install opencode"
+    print $"    \e[38;5;238mgemini\e[0m      brew install gemini"
+    print $"    \e[38;5;238mcodex\e[0m       npm install -g @openai/codex"
+    print $"\n  \e[38;5;75mThen run:\e[0m  lacy setup"
+    print $"  \e[38;5;75mDocs:\e[0m      https://lacy.sh/docs\n"
+}
+
+# Send a query to the active AI agent.
+def _lacy_query_agent [query: string] {
+    let tool = (_lacy_detect_tool)
+
+    if $tool == "" { _lacy_no_tool_error; return }
+
+    print ""
+    match $tool {
+        "lash"     => { ^lash run -c $query }
+        "claude"   => { ^claude -p $query }
+        "opencode" => { ^opencode run -c $query }
+        "gemini"   => { ^gemini -p $query }
+        "codex"    => { ^codex exec resume --last $query }
+        "custom"   => {
+            let cmd = ($env.LACY_CUSTOM_TOOL_CMD? | default "")
+            if $cmd == "" {
+                print --stderr "Lacy: custom tool set but LACY_CUSTOM_TOOL_CMD is empty"
+                return
+            }
+            let parts = ($cmd | split row ' ')
+            ^($parts | first) ...($parts | skip 1) $query
+        }
+        _ => { print --stderr $"Lacy: unknown tool '($tool)'" }
+    }
+    print ""
+}
+
+# Send the current commandline buffer to the agent.
+# Bound to Alt+Enter via keybindings.nu.
+def _lacy_send_to_agent [] {
+    let buf = (commandline)
+    if ($buf | str trim) == "" { return }
+
+    let route = (_lacy_classify_input $buf)
+    if $route != "agent" {
+        # Not natural language — let the user decide; show a hint and exit
+        print $"\n\e[38;5;238m  (Lacy: looks like a shell command — press Enter to execute normally)\e[0m"
+        return
+    }
+
+    commandline edit --replace ""
+    _lacy_query_agent $buf
+}
+
+# Public `lacy` command for manual agent queries.
+# Usage: lacy "why does this build fail?"
+export def lacy [query?: string] {
+    let q = if $query != null { $query } else {
+        input "Query: "
+    }
+    _lacy_query_agent $q
+}

--- a/lib/nu/keybindings.nu
+++ b/lib/nu/keybindings.nu
@@ -7,7 +7,7 @@
 #   Alt+Enter   — send current buffer to AI agent (_lacy_send_to_agent)
 #   Ctrl+Space  — cycle modes: auto → shell → agent → auto
 
-def _lacy_toggle_mode [] {
+def --env _lacy_toggle_mode [] {
     $env.LACY_SHELL_MODE = (match $env.LACY_SHELL_MODE {
         "auto"  => "shell"
         "shell" => "agent"

--- a/lib/nu/keybindings.nu
+++ b/lib/nu/keybindings.nu
@@ -1,0 +1,42 @@
+# Lacy Shell — Nushell keybindings
+#
+# Appends Lacy keybindings to $env.config.keybindings without clobbering
+# existing user bindings.
+#
+# Bindings:
+#   Alt+Enter   — send current buffer to AI agent (_lacy_send_to_agent)
+#   Ctrl+Space  — cycle modes: auto → shell → agent → auto
+
+def _lacy_toggle_mode [] {
+    $env.LACY_SHELL_MODE = (match $env.LACY_SHELL_MODE {
+        "auto"  => "shell"
+        "shell" => "agent"
+        _       => "auto"
+    })
+    match $env.LACY_SHELL_MODE {
+        "shell" => { print $"\n\e[38;5;34m  ▌ SHELL mode\e[0m" }
+        "agent" => { print $"\n\e[38;5;200m  ▌ AGENT mode\e[0m" }
+        _       => { print $"\n\e[38;5;75m  ▌ AUTO mode\e[0m" }
+    }
+}
+
+let _lacy_bindings = [
+    {
+        name: lacy_send_to_agent
+        modifier: alt
+        keycode: enter
+        mode: [emacs vi_insert vi_normal]
+        event: { send: executehostcommand cmd: "_lacy_send_to_agent" }
+    }
+    {
+        name: lacy_toggle_mode
+        modifier: control
+        keycode: space
+        mode: [emacs vi_insert vi_normal]
+        event: { send: executehostcommand cmd: "_lacy_toggle_mode" }
+    }
+]
+
+# Append to existing keybindings, preserving user config.
+let _existing_kb = (try { $env.config.keybindings } catch { [] })
+$env.config = ($env.config | upsert keybindings ($existing_kb | append $_lacy_bindings))

--- a/lib/nu/prompt.nu
+++ b/lib/nu/prompt.nu
@@ -1,0 +1,23 @@
+# Lacy Shell — Nushell prompt indicator
+#
+# Appends a colored mode badge to the right prompt.
+# Real-time per-keystroke indicator is not available in Nushell;
+# the badge updates on each new prompt.
+
+def _lacy_mode_badge [] -> string {
+    match ($env.LACY_SHELL_MODE? | default "auto") {
+        "shell" => $"\e[38;5;34mSHELL\e[0m"
+        "agent" => $"\e[38;5;200mAGENT\e[0m"
+        _       => $"\e[38;5;75mAUTO\e[0m"
+    }
+}
+
+# If PROMPT_COMMAND_RIGHT is already set, wrap it so both render.
+# Otherwise, install the badge as the right prompt.
+let _existing_right = ($env.PROMPT_COMMAND_RIGHT? | default null)
+
+$env.PROMPT_COMMAND_RIGHT = if $_existing_right != null {
+    { $"(do $_existing_right) (_lacy_mode_badge)" }
+} else {
+    { _lacy_mode_badge }
+}


### PR DESCRIPTION
## Summary

Closes #38. Adds Nushell support following the same structure as the Fish plugin (`lacy.plugin.fish` + `lib/fish/`).

- `lacy.plugin.nu` — entry point; source from `~/.config/nushell/config.nu`
- `lib/nu/config.nu` — globals, agent words, config.yaml loader
- `lib/nu/detection.nu` — `_lacy_classify_input` (uses `which` instead of `command -v`)
- `lib/nu/execute.nu` — `_lacy_query_agent`, `_lacy_send_to_agent`, public `lacy` command
- `lib/nu/keybindings.nu` — Alt+Enter (send to agent), Ctrl+Space (mode toggle)
- `lib/nu/prompt.nu` — right-prompt mode badge (SHELL / AGENT / AUTO)

**Nushell limitation:** Enter cannot be seamlessly overridden without losing interactive shell state (Nushell has no equivalent to ZSH's `zle accept-line` or Fish's `commandline -f execute`). Instead, normal Enter executes as shell and **Alt+Enter** routes the buffer to the agent. The `lacy "query"` command is also available for explicit queries.

Requires Nushell 0.87+. Zero changes to existing files.

## Test plan

- [ ] `source ~/.lacy/lacy.plugin.nu` in `~/.config/nushell/config.nu`
- [ ] Right prompt shows `AUTO` badge
- [ ] Ctrl+Space cycles through SHELL → AGENT → AUTO modes
- [ ] Alt+Enter with a natural-language buffer routes to agent
- [ ] `lacy "why does this fail?"` invokes the active AI tool
- [ ] `lacy` without args prompts for input
- [ ] Config from `~/.lacy/config.yaml` is picked up (active tool, default mode)