### PR TITLE
fix: make git optional for installation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in contributing to Lacy! This guide will help you get s
 ### Prerequisites
 
 - **ZSH** or **Bash 4+** (macOS ships with Bash 3.2 -- install Bash 4+ via `brew install bash`)
-- **Git**
+- **Git** (for development; not required for end-user installation)
 - An AI CLI tool for testing agent routing (Claude Code, Lash, Gemini CLI, etc.)
 
 ### Development Setup

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,7 @@ NC='\033[0m' # No Color
 # Installation directory
 INSTALL_DIR="${HOME}/.lacy"
 REPO_URL="https://github.com/lacymorrow/lacy.git"
+TARBALL_URL="https://github.com/lacymorrow/lacy/archive/refs/heads"
 CONFIG_FILE="${INSTALL_DIR}/config.yaml"
 
 # Release channel (set via --beta, --channel, or LACY_CHANNEL env var)
@@ -258,12 +259,11 @@ check_prerequisites() {
         missing=1
     fi
 
-    # Check for git
+    # Check for git (optional — curl fallback available)
     if command -v git >/dev/null 2>&1; then
         printf "  ${GREEN}✓${NC} git\n"
     else
-        printf "  ${RED}✗${NC} git (required)\n"
-        missing=1
+        printf "  ${YELLOW}○${NC} git (not found, will use curl fallback)\n"
     fi
 
     printf "\n"
@@ -430,6 +430,27 @@ install_lash() {
     fi
 }
 
+# Download and extract tarball (curl fallback when git is not available)
+install_via_tarball() {
+    local branch="$1"
+    local tarball_file
+    tarball_file=$(mktemp "${TMPDIR:-/tmp}/lacy-XXXXXX.tar.gz")
+
+    curl -fsSL "${TARBALL_URL}/${branch}.tar.gz" -o "$tarball_file" 2>/dev/null || {
+        rm -f "$tarball_file"
+        return 1
+    }
+
+    mkdir -p "$INSTALL_DIR"
+    tar xzf "$tarball_file" --strip-components=1 -C "$INSTALL_DIR" 2>/dev/null || {
+        rm -f "$tarball_file"
+        return 1
+    }
+
+    rm -f "$tarball_file"
+    return 0
+}
+
 # Clone or update repository
 install_plugin() {
     printf "${BLUE}Installing Lacy...${NC}\n"
@@ -440,19 +461,37 @@ install_plugin() {
         branch="$LACY_CHANNEL"
     fi
 
+    local has_git=0
+    command -v git >/dev/null 2>&1 && has_git=1
+
     if [[ -d "$INSTALL_DIR" ]]; then
         printf "${YELLOW}Existing installation found. Updating...${NC}\n"
-        cd "$INSTALL_DIR" || exit 1
-        git pull origin "$branch" 2>/dev/null || git pull origin main 2>/dev/null || git pull 2>/dev/null || {
-            printf "${YELLOW}Could not update, using existing installation${NC}\n"
-        }
+        if [[ $has_git -eq 1 && -d "$INSTALL_DIR/.git" ]]; then
+            cd "$INSTALL_DIR" || exit 1
+            git pull origin "$branch" 2>/dev/null || git pull origin main 2>/dev/null || git pull 2>/dev/null || {
+                printf "${YELLOW}Could not update, using existing installation${NC}\n"
+            }
+        else
+            install_via_tarball "$branch" || install_via_tarball "main" || {
+                printf "${YELLOW}Could not update, using existing installation${NC}\n"
+            }
+        fi
     else
-        # Try channel branch first, fall back to main
-        git clone --depth 1 -b "$branch" "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || \
-        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || {
-            printf "${RED}Failed to clone repository${NC}\n"
-            exit 1
-        }
+        if [[ $has_git -eq 1 ]]; then
+            git clone --depth 1 -b "$branch" "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || \
+            git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || {
+                # Git failed, try curl fallback
+                install_via_tarball "$branch" || install_via_tarball "main" || {
+                    printf "${RED}Failed to install repository${NC}\n"
+                    exit 1
+                }
+            }
+        else
+            install_via_tarball "$branch" || install_via_tarball "main" || {
+                printf "${RED}Failed to download repository${NC}\n"
+                exit 1
+            }
+        fi
     fi
 
     local version
@@ -779,7 +818,13 @@ check_existing_installation() {
                     printf "${RED}Could not find installation directory${NC}\n"
                     exit 1
                 }
-                if git pull origin main 2>/dev/null || git pull 2>/dev/null; then
+                local update_ok=0
+                if command -v git >/dev/null 2>&1 && [[ -d "$INSTALL_DIR/.git" ]]; then
+                    git pull origin main 2>/dev/null || git pull 2>/dev/null && update_ok=1
+                else
+                    install_via_tarball "main" && update_ok=1
+                fi
+                if [[ $update_ok -eq 1 ]]; then
                     local updated_version
                     updated_version=$(get_installed_version)
                     printf "${GREEN}✓ Lacy updated${NC}"

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -11,7 +11,7 @@ import {
   appendFileSync,
   rmSync,
 } from "fs";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -19,6 +19,7 @@ const INSTALL_DIR = join(homedir(), ".lacy");
 const INSTALL_DIR_OLD = join(homedir(), ".lacy-shell");
 const CONFIG_FILE = join(INSTALL_DIR, "config.yaml");
 const REPO_URL = "https://github.com/lacymorrow/lacy.git";
+const TARBALL_URL = "https://github.com/lacymorrow/lacy/archive/refs/heads";
 
 // Version — read from installed package.json (single source of truth),
 // fall back to this npm package's own package.json
@@ -188,6 +189,14 @@ function commandExists(cmd) {
   } catch {
     return false;
   }
+}
+
+function installViaTarball(branch) {
+  const tmpFile = join(tmpdir(), `lacy-${Date.now()}.tar.gz`);
+  execSync(`curl -fsSL "${TARBALL_URL}/${branch}.tar.gz" -o "${tmpFile}"`, { stdio: "pipe" });
+  mkdirSync(INSTALL_DIR, { recursive: true });
+  execSync(`tar xzf "${tmpFile}" --strip-components=1 -C "${INSTALL_DIR}"`, { stdio: "pipe" });
+  try { rmSync(tmpFile); } catch {}
 }
 
 function isInstalled() {
@@ -402,8 +411,6 @@ async function install() {
   } else {
     if (!commandExists("zsh")) missing.push("zsh");
   }
-
-  if (!commandExists("git")) missing.push("git");
 
   if (missing.length > 0) {
     prerequisites.stop("Prerequisites check failed");
@@ -736,24 +743,38 @@ async function install() {
   const installSpinner = p.spinner();
   installSpinner.start("Installing Lacy");
 
+  const hasGit = commandExists("git");
+
   try {
     if (existsSync(INSTALL_DIR)) {
       // Update existing
       try {
-        execSync("git pull origin main", { cwd: INSTALL_DIR, stdio: "pipe" });
+        if (hasGit && existsSync(join(INSTALL_DIR, ".git"))) {
+          execSync("git pull origin main", { cwd: INSTALL_DIR, stdio: "pipe" });
+        } else {
+          installViaTarball("main");
+        }
       } catch {
-        // Ignore pull errors, use existing
+        // Ignore update errors, use existing
       }
       installSpinner.stop("Lacy updated");
     } else {
-      execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, {
-        stdio: "pipe",
-      });
+      if (hasGit) {
+        try {
+          execSync(`git clone --depth 1 ${REPO_URL} "${INSTALL_DIR}"`, {
+            stdio: "pipe",
+          });
+        } catch {
+          installViaTarball("main");
+        }
+      } else {
+        installViaTarball("main");
+      }
       installSpinner.stop("Lacy installed");
     }
   } catch (e) {
     installSpinner.stop("Installation failed");
-    p.log.error(`Could not clone repository: ${e.message}`);
+    p.log.error(`Could not download repository: ${e.message}`);
     p.outro(pc.red("Installation failed"));
     process.exit(1);
   }
@@ -1140,7 +1161,11 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
           ? INSTALL_DIR
           : INSTALL_DIR_OLD;
         try {
-          execSync("git pull origin main", { cwd: updateDir, stdio: "pipe" });
+          if (commandExists("git") && existsSync(join(updateDir, ".git"))) {
+            execSync("git pull origin main", { cwd: updateDir, stdio: "pipe" });
+          } else {
+            installViaTarball("main");
+          }
           const updatedVersion = getVersion();
           updateSpinner.stop(`Lacy updated to v${updatedVersion}`);
           trackEvent("update", "npx");


### PR DESCRIPTION
## Summary
- Git is no longer a hard prerequisite for installing lacy
- When git is unavailable, the installer downloads a tarball from GitHub via curl instead
- Applies to both `install.sh` (bash installer) and `packages/lacy/index.mjs` (Node installer)
- Covers fresh installs, updates, and the existing-installation menu
- ZSH was already correctly handled (only required when detected shell is zsh, not bash)

## Test plan
- [ ] Run `install.sh` on a system without git — verify it installs via tarball
- [ ] Run `npx lacy` on a system without git — verify it installs via tarball
- [ ] Run update flow without git — verify tarball update works
- [ ] Run install with git available — verify git clone still preferred
- [ ] Verify prerequisite output shows yellow "will use curl fallback" for missing git