### PR TITLE
fix: resolve process hanging after npx installer completes

### DIFF
--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -252,6 +252,13 @@ async function restartShell(
     // Restore terminal state before handing off to the new shell
     restoreTerminalState();
 
+    // Remove signal handlers so Ctrl+C in the child shell doesn't kill Node.
+    // The child shell manages its own signals; Node just waits for it to exit.
+    for (const sig of ["SIGINT", "SIGTERM", "SIGHUP"]) {
+      process.removeAllListeners(sig);
+    }
+    process.on("SIGINT", () => {});
+
     // Spawn a new login shell that inherits our stdio, then exit Node.
     // We use spawn (not execSync) to avoid creating a nested shell —
     // execSync("exec ...") only replaces the *child* process, not Node,
@@ -1216,7 +1223,9 @@ ${pc.dim("https://github.com/lacymorrow/lacy")}
   await install();
 }
 
-main().catch((e) => {
+main().then(() => {
+  process.exit(0);
+}).catch((e) => {
   restoreTerminalState();
   p.log.error(e.message);
   process.exit(1);


### PR DESCRIPTION
## Summary
- Fix Node process hanging for up to 5 seconds after `npx lacy` install completes (analytics `fetch()` with `AbortSignal.timeout(5000)` kept the event loop alive)
- Fix potential terminal corruption when Ctrl+C is pressed inside the spawned child shell (Node's SIGINT handler could kill Node and orphan the shell process)

## Changes
- Add `process.exit(0)` in `main().then()` so the process exits immediately on success instead of waiting for pending timers
- Remove signal handlers and install a no-op SIGINT handler before spawning the child shell in `restartShell()`

## Test plan
- [ ] Run `npx lacy` on a fresh system — verify installer completes and process exits promptly
- [ ] Run `npx lacy` on an already-installed system — verify dashboard works and "Done" exits immediately
- [ ] Run `curl -fsSL https://lacy.sh/install | bash` — verify same behavior
- [ ] Accept shell restart after install — verify Ctrl+C in the new shell works normally
- [ ] Decline shell restart — verify process exits immediately (no 5s hang)

Closes LAC-1599