### PR TITLE
fix: remove false zsh/git requirements when running in bash

### DIFF
--- a/bin/lacy
+++ b/bin/lacy
@@ -63,11 +63,36 @@ command_exists() {
 
 detect_shell() {
     local shell
-    shell=$(basename "${SHELL:-zsh}")
+    shell=$(basename "${SHELL:-}")
     case "$shell" in
         zsh|bash) echo "$shell" ;;
-        *) echo "zsh" ;;
+        *)
+            # Detect from the running process if $SHELL is unhelpful
+            if [[ -n "${BASH_VERSION:-}" ]]; then
+                echo "bash"
+            elif [[ -n "${ZSH_VERSION:-}" ]]; then
+                echo "zsh"
+            elif command_exists bash; then
+                echo "bash"
+            elif command_exists zsh; then
+                echo "zsh"
+            else
+                echo "bash"
+            fi
+            ;;
     esac
+}
+
+update_via_tarball() {
+    local dir="$1"
+    local tarball_url="https://github.com/lacymorrow/lacy/archive/refs/heads/main.tar.gz"
+    local tmp_file
+    tmp_file=$(mktemp)
+    curl -fsSL "$tarball_url" -o "$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 1; }
+    # Extract over existing directory
+    tar xzf "$tmp_file" --strip-components=1 -C "$dir" 2>/dev/null || { rm -f "$tmp_file"; return 1; }
+    rm -f "$tmp_file"
+    return 0
 }
 
 get_rc_file() {
@@ -237,20 +262,21 @@ cmd_update() {
 
     info "Updating Lacy Shell..."
 
-    if [[ -d "${dir}/.git" ]]; then
+    if [[ -d "${dir}/.git" ]] && command_exists git; then
         if git -C "$dir" pull origin main 2>/dev/null || git -C "$dir" pull 2>/dev/null; then
-            # Re-read version after update
             VERSION="$(get_version)"
             VERSION="${VERSION:-$VERSION_FALLBACK}"
             success "Lacy Shell updated to v${VERSION}"
         else
             die "Update failed. Try: lacy reinstall"
         fi
+    elif command_exists curl; then
+        update_via_tarball "$dir" || die "Update failed. Try: lacy reinstall"
+        VERSION="$(get_version)"
+        VERSION="${VERSION:-$VERSION_FALLBACK}"
+        success "Lacy Shell updated to v${VERSION}"
     else
-        warn "Not a git repo. Reinstalling..."
-        rm -rf "$dir"
-        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || die "Clone failed"
-        success "Lacy Shell reinstalled"
+        die "Neither git nor curl available. Cannot update."
     fi
 }
 
@@ -268,8 +294,22 @@ cmd_reinstall() {
     [[ -d "$INSTALL_DIR" ]] && rm -rf "$INSTALL_DIR"
     [[ -d "$INSTALL_DIR_OLD" ]] && rm -rf "$INSTALL_DIR_OLD"
 
-    # Clone fresh
-    git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" 2>/dev/null || die "Clone failed"
+    # Install fresh (git with tarball fallback)
+    local installed=false
+    if command_exists git; then
+        git clone --depth 1 "$REPO_URL" "$INSTALL_DIR" 2>/dev/null && installed=true
+    fi
+    if [[ "$installed" == false ]] && command_exists curl; then
+        local tarball_url="https://github.com/lacymorrow/lacy/archive/refs/heads/main.tar.gz"
+        local tmp_file
+        tmp_file=$(mktemp)
+        curl -fsSL "$tarball_url" -o "$tmp_file" 2>/dev/null && \
+            mkdir -p "$INSTALL_DIR" && \
+            tar xzf "$tmp_file" --strip-components=1 -C "$INSTALL_DIR" 2>/dev/null && \
+            installed=true
+        rm -f "$tmp_file"
+    fi
+    [[ "$installed" == false ]] && die "Install failed. Need git or curl."
 
     # Restore user config
     if [[ -n "$config_backup" ]]; then
@@ -457,12 +497,11 @@ cmd_doctor() {
         issues=$((issues + 1))
     fi
 
-    # Check git
+    # Check git (optional — tarball fallback available)
     if command_exists git; then
         success "git available"
     else
-        printf "  ${RED}✗${NC} git not found (required for updates)\n"
-        issues=$((issues + 1))
+        printf "  ${YELLOW}○${NC} git not found (optional, updates use curl fallback)\n"
     fi
 
     # Check curl

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,20 @@ detect_user_shell() {
         zsh)  DETECTED_SHELL="zsh" ;;
         bash) DETECTED_SHELL="bash" ;;
         fish) DETECTED_SHELL="fish" ;;
-        *)    DETECTED_SHELL="zsh" ;;
+        *)
+            # Detect from running process or what's available
+            if [[ -n "${BASH_VERSION:-}" ]]; then
+                DETECTED_SHELL="bash"
+            elif [[ -n "${ZSH_VERSION:-}" ]]; then
+                DETECTED_SHELL="zsh"
+            elif command -v zsh >/dev/null 2>&1; then
+                DETECTED_SHELL="zsh"
+            elif command -v bash >/dev/null 2>&1; then
+                DETECTED_SHELL="bash"
+            else
+                DETECTED_SHELL="bash"
+            fi
+            ;;
     esac
 }
 

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -81,7 +81,11 @@ function detectShell() {
   const shell = process.env.SHELL || "";
   const base = shell.split("/").pop();
   if (base === "bash") return "bash";
-  return "zsh"; // default
+  if (base === "zsh") return "zsh";
+  // Unknown $SHELL — check what's available
+  if (commandExists("zsh")) return "zsh";
+  if (commandExists("bash")) return "bash";
+  return "bash";
 }
 
 function getShellConfig(shell) {


### PR DESCRIPTION
## Summary

- Shell detection (`bin/lacy`, `install.sh`, `index.mjs`) no longer blindly defaults to "zsh" when `$SHELL` is unknown — it checks the running process and available shells first
- `lacy doctor` now shows git as optional (yellow indicator) instead of a required red error
- `lacy update` and `lacy reinstall` use curl/tarball fallback when git is unavailable, matching the installer behavior from #60

## Test plan

- [x] `bash -n bin/lacy` passes
- [x] `bash -n install.sh` passes
- [x] `bash tests/test_core.sh` — 158 tests pass
- [x] `bash tests/test_bash.bash` — 16 tests pass
- [ ] Manual: run `SHELL=/bin/fish bin/lacy doctor` to verify it detects bash (not zsh)
- [ ] Manual: run `lacy doctor` on a system without git to verify yellow "optional" message