### PR TITLE
fix: use user's actual bash for version check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -248,8 +248,14 @@ check_prerequisites() {
             ;;
         bash)
             if command -v bash >/dev/null 2>&1; then
-                local bash_version
-                bash_version=$(bash -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null || echo "0")
+                local bash_version user_bash
+                # Use the user's $SHELL if it's bash — on macOS, plain `bash` resolves
+                # to /bin/bash (3.2) even when the user has a newer bash as their shell
+                case "${SHELL:-}" in
+                    */bash) user_bash="$SHELL" ;;
+                    *)      user_bash="bash" ;;
+                esac
+                bash_version=$("$user_bash" -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null || bash -c 'echo ${BASH_VERSINFO[0]}' 2>/dev/null || echo "0")
                 if [[ "$bash_version" -ge 4 ]]; then
                     printf "  ${GREEN}✓${NC} bash ${bash_version}+\n"
                 else

--- a/lib/bash/init.bash
+++ b/lib/bash/init.bash
@@ -4,7 +4,7 @@
 
 # Require Bash 4+ (for declare -A, ${var,,}, READLINE_LINE)
 if [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
-    echo "Lacy Shell requires Bash 4+. You have Bash ${BASH_VERSION}."
+    echo "Lacy Shell requires Bash 4 or later. You have Bash ${BASH_VERSION}."
     echo ""
     echo "Upgrade options:"
     echo "  macOS:  brew install bash"

--- a/packages/lacy/index.mjs
+++ b/packages/lacy/index.mjs
@@ -403,11 +403,20 @@ async function install() {
   if (shell === "bash") {
     if (commandExists("bash")) {
       try {
-        const bashVer = execSync('bash -c "echo ${BASH_VERSINFO[0]}"', {
-          stdio: "pipe",
-        })
-          .toString()
-          .trim();
+        // Use $SHELL if it's bash — on macOS, plain `bash` resolves to /bin/bash (3.2)
+        // even when the user has a newer bash (e.g. 5.x from Homebrew) as their login shell
+        const shellEnv = process.env.SHELL || "";
+        const userBash = shellEnv.endsWith("/bash") ? shellEnv : "bash";
+        let bashVer;
+        try {
+          bashVer = execSync(`"${userBash}" -c "echo \\${BASH_VERSINFO[0]}"`, {
+            stdio: "pipe",
+          }).toString().trim();
+        } catch {
+          bashVer = execSync('bash -c "echo ${BASH_VERSINFO[0]}"', {
+            stdio: "pipe",
+          }).toString().trim();
+        }
         if (parseInt(bashVer) < 4) {
           missing.push(
             `bash 4+ (found bash ${bashVer}, upgrade with: brew install bash)`,


### PR DESCRIPTION
## Summary
- On macOS, `bash -c ...` resolves to `/bin/bash` (3.2) even when the user's `$SHELL` is a newer Homebrew bash (e.g. 5.3). The installer would incorrectly reject these users with "bash 4+ required (found bash 3)".
- Now checks `$SHELL` first when it points to bash, falling back to the generic `bash` command. Applied to both `install.sh` and the Node installer (`packages/lacy/index.mjs`).
- Clarified the init.bash error message from "requires Bash 4+" to "requires Bash 4 or later".

## Test plan
- [ ] On macOS with Homebrew bash 5.x as `$SHELL` and system `/bin/bash` 3.2: run `npx lacy` and verify prerequisites pass
- [ ] On macOS with zsh as `$SHELL`: run installer targeting bash, verify it still checks correctly
- [ ] On Linux (where `bash` is typically 5.x): verify no regression

Closes LAC-1601