### PR TITLE
chore: fix package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lacymorrow/lacy.git"
+    "url": "git+https://github.com/lacymorrow/lacy.git"
   },
   "bugs": {
     "url": "https://github.com/lacymorrow/lacy/issues"


### PR DESCRIPTION
## Summary
- Normalize `repository` field in package.json per npm publish standards
- Convert string shorthand to object format with `type` and `url`
- Normalize URLs to `git+https://` format

Automated fix via `npm pkg fix`. Addresses npm publish warnings.