### PR TITLE
fix: suppress npm error during uninstall and offer shell restart

### DIFF
--- a/bin/lacy
+++ b/bin/lacy
@@ -251,6 +251,7 @@ cmd_uninstall() {
     printf "\n${GREEN}Lacy Shell uninstalled.${NC}\n"
 
     offer_restart
+    echo "Restart your terminal to apply changes."
 }
 
 cmd_update() {

--- a/bin/lacy
+++ b/bin/lacy
@@ -191,8 +191,8 @@ cmd_uninstall() {
         exit 0
     fi
 
-    # Try fancy Node uninstaller first
-    try_node --uninstall || true
+    # Try fancy Node uninstaller first (suppress npx errors — bash fallback handles it)
+    try_node --uninstall 2>/dev/null || true
 
     # Bash fallback
     if [[ -t 0 ]]; then
@@ -249,7 +249,8 @@ cmd_uninstall() {
     fi
 
     printf "\n${GREEN}Lacy Shell uninstalled.${NC}\n"
-    echo "Restart your terminal to apply changes."
+
+    offer_restart
 }
 
 cmd_update() {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -49,4 +49,15 @@ fi
 
 echo ""
 echo "Lacy Shell uninstalled."
+
+# Offer to restart the shell
+if [[ -t 0 ]]; then
+    printf "Restart shell now to apply changes? [Y/n]: "
+    read -r restart
+    if [[ ! "$restart" =~ ^[Nn]$ ]]; then
+        shell_cmd=$(basename "${SHELL:-bash}")
+        echo "Restarting ${shell_cmd}..."
+        exec "$shell_cmd" -l
+    fi
+fi
 echo "Restart your terminal to apply changes."


### PR DESCRIPTION
## Summary
- Suppress npx stderr during uninstall so users don't see the confusing `npm error could not determine executable to run` message when the Node uninstaller fails to resolve — the bash fallback already handles uninstall cleanly
- Replace static "Restart your terminal" message with an interactive offer to `exec` a fresh login shell, so lacy is fully deactivated in the current session after uninstall
- Fix applied to both `bin/lacy` (CLI) and `uninstall.sh` (standalone script)

Closes LAC-1963

## Test plan
- [ ] Run `lacy uninstall` — verify no npm error is displayed
- [ ] Confirm the uninstall prompt appears and works
- [ ] After confirming uninstall, verify "Restart shell now?" prompt appears
- [ ] Accept restart — verify shell restarts cleanly without lacy active
- [ ] Decline restart — verify fallback message "Restart your terminal" is shown