### PR TITLE
fix: sync npm package version and prevent root publish

### DIFF
--- a/bin/lacy
+++ b/bin/lacy
@@ -9,7 +9,7 @@
 
 set -e
 
-VERSION_FALLBACK="1.8.11"
+VERSION_FALLBACK="1.8.15"
 INSTALL_DIR="${HOME}/.lacy"
 INSTALL_DIR_OLD="${HOME}/.lacy-shell"
 CONFIG_FILE="${INSTALL_DIR}/config.yaml"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lacy",
   "version": "1.8.15",
+  "private": true,
   "description": "Talk to your terminal — AI agent routing for your shell",
   "main": "lacy.plugin.zsh",
   "scripts": {

--- a/packages/lacy/package-lock.json
+++ b/packages/lacy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lacy",
-  "version": "1.7.2",
+  "version": "1.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lacy",
-      "version": "1.7.2",
+      "version": "1.8.15",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/packages/lacy/package.json
+++ b/packages/lacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lacy",
-  "version": "1.8.11",
+  "version": "1.8.15",
   "description": "Install lacy — talk to your terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **Root cause:** Releases v1.8.12-v1.8.15 were published from the repo root instead of `packages/lacy/`, so the published npm package had no `bin` field, causing `npx lacy` to fail with "could not determine executable to run"
- **Fix:** Sync `packages/lacy/package.json` version to 1.8.15, update `bin/lacy` `VERSION_FALLBACK`, and add `"private": true` to root `package.json` to prevent accidental root publishes in the future
- **After merge:** A new release (v1.8.16) must be published using `bun run release` so the npm package gets the correct `bin` field from `packages/lacy/`

Fixes LAC-2055. Related: LAC-1963.

## Test plan

- [ ] Merge this PR
- [ ] Run `bun run release patch` to publish v1.8.16 from the correct directory
- [ ] Verify `npx lacy` works: `npm view lacy@latest bin` should show `{ lacy: "index.mjs" }`
- [ ] Verify `npm publish` from root fails with "private" error (safeguard)