### PR TITLE
fix: prevent root publish, sync subpackage version, regenerate lockfile

### DIFF
--- a/bin/lacy
+++ b/bin/lacy
@@ -9,7 +9,7 @@
 
 set -e
 
-VERSION_FALLBACK="1.8.11"
+VERSION_FALLBACK="1.8.17"
 INSTALL_DIR="${HOME}/.lacy"
 INSTALL_DIR_OLD="${HOME}/.lacy-shell"
 CONFIG_FILE="${INSTALL_DIR}/config.yaml"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "lacy",
   "version": "1.8.17",
+  "private": true,
   "description": "Talk to your terminal — AI agent routing for your shell",
   "main": "lacy.plugin.zsh",
   "scripts": {

--- a/packages/lacy/package-lock.json
+++ b/packages/lacy/package-lock.json
@@ -56,7 +56,7 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.2.0",
+      "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"

--- a/packages/lacy/package-lock.json
+++ b/packages/lacy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lacy",
-  "version": "1.7.2",
+  "version": "1.8.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lacy",
-      "version": "1.7.2",
+      "version": "1.8.17",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/packages/lacy/package.json
+++ b/packages/lacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lacy",
-  "version": "1.8.11",
+  "version": "1.8.17",
   "description": "Install lacy — talk to your terminal",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Releases v1.8.12 through v1.8.17 published the root \`package.json\` to npm — the root has no \`bin\` field, so \`npx lacy\` errors with "could not determine executable to run". The real npm package lives in \`packages/lacy/\` and had drifted to 1.8.11 because the new release tool (shipx) only bumped root.

- Sync \`packages/lacy/package.json\` to 1.8.17
- Sync \`bin/lacy\` VERSION_FALLBACK to 1.8.17
- Regenerate \`packages/lacy/package-lock.json\` (was stuck at 1.7.2)
- Add \`"private": true\` to root \`package.json\` so any future publish from root fails loudly instead of shipping a broken npm package

This is a stop-gap — a proper fix in shipx (auto-detect the publishable subpackage) is in https://github.com/lacymorrow/shipx/pull/49. Once that's released, lacy releases will work zero-config.

## Test plan
- [ ] Verify \`packages/lacy/package.json\` version matches root (1.8.17)
- [ ] Verify \`bin/lacy\` VERSION_FALLBACK is 1.8.17
- [ ] Verify root \`package.json\` has \`"private": true\`
- [ ] \`cd packages/lacy && npm pack --dry-run\` — confirm it produces a small tarball with index.mjs only
- [ ] After merging, run the shipx-fixed release path to publish v1.8.18 with a working \`bin\` field; \`npx lacy@1.8.18\` should run the installer