### PR TITLE
fix: use `command rm` for internal state cleanup

### DIFF
--- a/lib/core/commands.sh
+++ b/lib/core/commands.sh
@@ -271,7 +271,7 @@ lacy_shell_spinner() {
 # === Conversation Management ===
 
 lacy_shell_clear_conversation() {
-    rm -f "$LACY_SHELL_CONVERSATION_FILE"
+    command rm -f "$LACY_SHELL_CONVERSATION_FILE"
     echo "$LACY_MSG_CONVERSATION_CLEARED"
 }
 

--- a/lib/core/context.sh
+++ b/lib/core/context.sh
@@ -71,9 +71,9 @@ _lacy_ctx_detect_terminal() {
 _lacy_ctx_screen_capture() {
     local tmpfile
     tmpfile=$(mktemp) || return
-    screen -X hardcopy "$tmpfile" 2>/dev/null || { rm -f "$tmpfile"; return; }
+    screen -X hardcopy "$tmpfile" 2>/dev/null || { command rm -f "$tmpfile"; return; }
     cat "$tmpfile" 2>/dev/null
-    rm -f "$tmpfile" 2>/dev/null
+    command rm -f "$tmpfile" 2>/dev/null
 }
 
 # iTerm2: AppleScript to get current session contents

--- a/lib/core/mcp.sh
+++ b/lib/core/mcp.sh
@@ -387,7 +387,7 @@ EOF
             lacy_shell_send_to_ai_streaming "$temp_file" "$query"
             local exit_code=$?
             lacy_stop_spinner
-            rm -f "$temp_file"
+            command rm -f "$temp_file"
             echo ""
             return $exit_code
         fi

--- a/lib/core/preheat.sh
+++ b/lib/core/preheat.sh
@@ -169,7 +169,7 @@ lacy_preheat_server_query() {
     local exit_code=$?
     if [[ $exit_code -ne 0 ]]; then
         LACY_PREHEAT_SERVER_SESSION_ID=""
-        rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
+        command rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
         return 1
     fi
 
@@ -225,12 +225,12 @@ lacy_preheat_server_stop() {
             kill "$file_pid" 2>/dev/null
             wait "$file_pid" 2>/dev/null
         fi
-        rm -f "$LACY_PREHEAT_SERVER_PID_FILE"
+        command rm -f "$LACY_PREHEAT_SERVER_PID_FILE"
     fi
 
     LACY_PREHEAT_SERVER_PASSWORD=""
     LACY_PREHEAT_SERVER_SESSION_ID=""
-    rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
+    command rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
 }
 
 # Restore server session ID from file (survives subshell boundary)
@@ -301,7 +301,7 @@ _lacy_session_reset() {
     local file="$1"
     local var_name="$2"
     printf -v "$var_name" '%s' ""
-    rm -f "$file"
+    command rm -f "$file"
 }
 
 # ============================================================================
@@ -399,7 +399,7 @@ lacy_session_new() {
     lacy_preheat_claude_reset_session
     lacy_preheat_gemini_reset_session
     LACY_PREHEAT_SERVER_SESSION_ID=""
-    rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
+    command rm -f "$LACY_PREHEAT_SERVER_SESSION_FILE"
 
     # Reset terminal context so the next query sends full context
     _lacy_ctx_reset
@@ -491,6 +491,6 @@ lacy_preheat_init() {
 
 lacy_preheat_cleanup() {
     lacy_preheat_server_stop
-    rm -f "$LACY_PREHEAT_SESSION_FILE" \
-          "$LACY_GEMINI_SESSION_ID_FILE"
+    command rm -f "$LACY_PREHEAT_SESSION_FILE" \
+                  "$LACY_GEMINI_SESSION_ID_FILE"
 }


### PR DESCRIPTION
## Summary
- Users who alias `rm` to `trash` (common macOS habit) saw noisy "file doesn't exist" errors from the trash CLI when running things like `tool set claude`, because `trash` doesn't honor `rm -f` semantics on missing files.
- Switches internal state-file cleanup in `lib/core/{preheat,context,mcp,commands}.sh` to `command rm -f` so it bypasses user aliases.
- Install/uninstall paths in `bin/lacy` are intentionally left alone — trash semantics may be desirable there.

## Repro (before)
```
$ tool set claude
2026-05-25 ... trash[...] # Error attempting to move /Users/lacy/.lacy/.server_session_id_56928 to the trash folder ...
2026-05-25 ... trash[...] # Error attempting to move /Users/lacy/.lacy/.claude_session_id_56928 ...
2026-05-25 ... trash[...] # Error attempting to move /Users/lacy/.lacy/.gemini_session_id_56928 ...
Tool set to: claude
```

## Test plan
- [ ] With `alias rm=trash` in shell: `tool set claude` produces no noise
- [ ] `tool set auto` / `tool set lash` likewise silent
- [ ] `/new` session doesn't emit trash errors
- [ ] Without the alias, behavior unchanged (silent cleanup as before)